### PR TITLE
Add unit tests for new Pascal features

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -27,7 +27,7 @@ enum_item:   CNAME ("=" NUMBER)?                              -> enum_item
 
 class_signature: member_decl*                                     -> class_sign
 member_decl: attributes? method_decl_rule
-           | attributes? access_modifier? "class"? "var"i? name_list ":" type_name (":=" expr)? ";"         -> field_decl
+           | attributes? access_modifier? class_modifier? VAR? name_list ":" type_name (":=" expr)? ";"         -> field_decl
            | attributes? access_modifier? "class"? "property"i property_sig ";"          -> property_decl
            | attributes? access_modifier? "event"i CNAME ":" type_name ";"   -> event_decl
            | attributes? access_modifier? "class"? "const"i const_decl+                  -> const_block

--- a/grammar.py
+++ b/grammar.py
@@ -1,6 +1,6 @@
 # ────────────────────────── Grammar ──────────────────────────
 GRAMMAR = r"""
-?start:      namespace interface_section? class_section ("implementation" class_impl*)? ("end" ".")?
+?start:      namespace interface_section? class_section ("implementation" uses_clause? class_impl*)? ("end" ".")?
 
 interface_section: "interface" uses_clause? pre_class_decl*
 uses_clause:   "uses" dotted_name ("," dotted_name)* ";"         -> uses
@@ -15,23 +15,25 @@ type_def:    attributes? class_def
            | attributes? record_def
            | attributes? interface_def
            | attributes? enum_def
+           | alias_def
 
-class_def:   CNAME "=" "public"i "static"? "partial"? "abstract"? "class"i ("(" type_name ")")? class_signature "end"i ";" -> class_def
-record_def:  CNAME "=" "public"i "record"i ("(" type_name ")")? class_signature "end"i ";" -> record_def
-interface_def: CNAME "=" "public"i "interface"i ("(" type_name ("," type_name)* ")")? class_signature "end"i ";" -> interface_def
-enum_def:    CNAME "=" "public"i ("enum"i | "flags"i) "(" enum_items ")" ("of" type_name)? ";" -> enum_def
+class_def:   CNAME "=" ("public"i)? "static"? "partial"? "abstract"? "class"i ("(" type_name ")")? class_signature "end"i ";" -> class_def
+record_def:  CNAME "=" ("public"i)? "record"i ("(" type_name ")")? class_signature "end"i ";" -> record_def
+interface_def: CNAME "=" ("public"i)? "interface"i ("(" type_name ("," type_name)* ")")? class_signature "end"i ";" -> interface_def
+enum_def:    CNAME "=" ("public"i)? ("enum"i | "flags"i)? "(" enum_items ")" ("of" type_name)? ";" -> enum_def
+alias_def:   CNAME "=" type_name ";"                        -> alias_def
 enum_items:  enum_item ("," enum_item)*                       -> enum_items
 enum_item:   CNAME ("=" NUMBER)?                              -> enum_item
 
 class_signature: member_decl*                                     -> class_sign
 member_decl: attributes? method_decl_rule
-           | attributes? access_modifier? "class"? "var"i? name_list ":" type_name ";"         -> field_decl
+           | attributes? access_modifier? "class"? "var"i? name_list ":" type_name (":=" expr)? ";"         -> field_decl
            | attributes? access_modifier? "class"? "property"i property_sig ";"          -> property_decl
            | attributes? access_modifier? "event"i CNAME ":" type_name ";"   -> event_decl
            | attributes? access_modifier? "class"? "const"i const_decl+                  -> const_block
            | access_modifier                                      -> section
 
-method_decl_rule: access_modifier? class_modifier? method_kind method_sig ";" method_attr* ";"? -> method_decl
+method_decl_rule: access_modifier? class_modifier? method_kind method_sig ";" (method_attr ";"?)* -> method_decl
 
 class_modifier: "class"
 method_attr: "override" | "static" | "abstract" | "virtual"
@@ -109,7 +111,7 @@ raise_stmt: RAISE expr? ";"?                                 -> raise_stmt
 repeat_stmt: "repeat"i stmt* "until"i expr ";"?               -> repeat_stmt
 break_stmt: BREAK ";"?                                     -> break_stmt
 continue_stmt: CONTINUE ";"?                                -> continue_stmt
-using_stmt: USING CNAME ":=" expr DO stmt                  -> using_var
+using_stmt: USING CNAME (":" type_name)? ":=" expr DO stmt                  -> using_var
            | USING expr DO stmt                           -> using_expr
            | USING AUTORELEASEPOOL DO stmt                -> using_pool
 locking_stmt: LOCKING expr DO stmt                        -> locking_stmt
@@ -117,7 +119,7 @@ with_stmt: WITH expr DO stmt                              -> with_stmt
 yield_stmt: YIELD expr ";"?                               -> yield_stmt
 if_stmt:     "if" expr "then" stmt ("else" stmt)?                 -> if_stmt
 for_stmt:    "for"i CNAME ":=" expr (TO | DOWNTO) expr (STEP expr)? ("do"i)? stmt  -> for_stmt
-           | "for"i "each"i? CNAME IN expr ("do"i)? stmt        -> for_each_stmt
+           | "for"i "each"i? CNAME (":" type_name)? IN expr ("do"i)? stmt        -> for_each_stmt
 loop_stmt:   LOOP stmt                                                -> loop_stmt
 while_stmt:  "while"i expr "do"i stmt        -> while_stmt
 try_stmt:    "try" stmt* ("except" stmt*)? ("finally" stmt*)? "end" ";"?
@@ -147,15 +149,19 @@ inherited_stmt: "inherited" ";"?                          -> inherited
            | TRUE                         -> true
            | FALSE                        -> false
            | NIL                          -> null
+           | TYPEOF "(" type_name ")"      -> typeof_expr
            | var_ref
            | call_expr
            | set_lit
            | new_expr
+           | CHAR_CODE                    -> char_code
            | expr CARET                  -> deref
 
 set_lit: "[" (expr ("," expr)*)? "]"
 
-new_expr: "new" type_name ("(" arg_list? ")")?
+new_expr: "new" type_name "(" arg_list? ")"           -> new_obj
+        | "new" type_name ARRAY_RANGE                 -> new_array
+        | "new" type_name                             -> new_obj_noargs
 
 generic_call_base: dotted_name GENERIC_ARGS
 
@@ -181,7 +187,7 @@ var_decl:    name_list ":" type_name (":=" expr)? ";"        -> var_decl
 
 LT:          "<"
 GT:          ">"
-GENERIC_ARGS: /<\s*[A-Za-z0-9][^>]*>/
+GENERIC_ARGS: /<(?:(?:[^<>]|<[^<>]*>)+)>/
 OP_SUM:      "+" | "-" | "or"
 OP_MUL:      "*" | "/" | "and" | "mod"i
 OP_REL:      "=" | "<>" | "<=" | ">="
@@ -232,14 +238,19 @@ FLAGS:       "flags"i
 EVENT:       "event"i
 OPERATOR:    "operator"i
 TUPLE:       "tuple"i
+TYPEOF:      "typeof"i
 AT:          "@"
 CARET:       "^"
 DOTDOT:      ".."
 
-%import common.CNAME
+CHAR_CODE:   "#" NUMBER
+
+%import common.CNAME -> BASE_CNAME
 %import common.NUMBER
 %import common.ESCAPED_STRING -> STRING
 %import common.WS
+
+CNAME: /&?[A-Za-z_][A-Za-z_0-9]*/
 COMMENT_BRACE: /\{[^}]*\}/
 LINE_COMMENT: /\/\/[^\n]*/
 COMMENT_PAREN: /\(\*[^*]*\*\)/

--- a/tests/AliasDef.cs
+++ b/tests/AliasDef.cs
@@ -1,3 +1,5 @@
+using MimeMappingType = Type;
+
 namespace Demo {
     public partial class AliasHolder {
     

--- a/tests/AliasDef.cs
+++ b/tests/AliasDef.cs
@@ -1,0 +1,5 @@
+namespace Demo {
+    public partial class AliasHolder {
+    
+    }
+}

--- a/tests/AliasDef.pas
+++ b/tests/AliasDef.pas
@@ -1,0 +1,9 @@
+namespace Demo;
+
+type
+  MimeMappingType = &Type;
+
+  AliasHolder = public class
+  end;
+
+end.

--- a/tests/CharCode.cs
+++ b/tests/CharCode.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class CharCodeExample {
+        public static string GetNewline() {
+            return "\r" + "\n";
+        }
+    }
+}

--- a/tests/CharCode.pas
+++ b/tests/CharCode.pas
@@ -1,0 +1,16 @@
+namespace Demo;
+
+type
+  CharCodeExample = public class
+  public
+    class method GetNewline: String;
+  end;
+
+implementation
+
+class method CharCodeExample.GetNewline: String;
+begin
+  result := #13 + #10;
+end;
+
+end.

--- a/tests/ClassVar.cs
+++ b/tests/ClassVar.cs
@@ -1,6 +1,6 @@
 namespace Demo {
     public partial class Logger {
         // TODO: field Log: int -> declare a field
-        public int Log;
+        public static int Log;
     }
 }

--- a/tests/FieldInit.cs
+++ b/tests/FieldInit.cs
@@ -1,0 +1,6 @@
+namespace Demo {
+    public partial class FieldInit {
+        // TODO: field Count: int -> declare a field
+        public int Count = 1;
+    }
+}

--- a/tests/FieldInit.pas
+++ b/tests/FieldInit.pas
@@ -1,0 +1,9 @@
+namespace Demo;
+
+type
+  FieldInit = class
+  public
+    var Count: Integer := 1;
+  end;
+
+end.

--- a/tests/TypeOfNew.cs
+++ b/tests/TypeOfNew.cs
@@ -1,0 +1,10 @@
+namespace Demo {
+    public partial class TypeOfNew {
+        public static Byte[] MakeArray(int len) {
+            return new Byte[len];
+        }
+        public static void Show() {
+            Console.WriteLine(typeof(int));
+        }
+    }
+}

--- a/tests/TypeOfNew.pas
+++ b/tests/TypeOfNew.pas
@@ -1,0 +1,22 @@
+namespace Demo;
+
+type
+  TypeOfNew = class
+  public
+    class method MakeArray(len: Integer): array of Byte;
+    class method Show;
+  end;
+
+implementation
+
+class method TypeOfNew.MakeArray(len: Integer): array of Byte;
+begin
+  result := new Byte[len];
+end;
+
+class method TypeOfNew.Show;
+begin
+  Console.WriteLine(typeof(Integer));
+end;
+
+end.

--- a/tests/TypedForEach.cs
+++ b/tests/TypedForEach.cs
@@ -1,0 +1,10 @@
+namespace Demo {
+    public partial class TypedForEach {
+        public static int Sum(int[] arr) {
+            int total;
+            total = 0;
+            foreach (int item in arr) total = total + item;
+            return total;
+        }
+    }
+}

--- a/tests/TypedForEach.pas
+++ b/tests/TypedForEach.pas
@@ -1,0 +1,21 @@
+namespace Demo;
+
+type
+  TypedForEach = class
+  public
+    class method Sum(arr: array of Integer): Integer;
+  end;
+
+implementation
+
+class method TypedForEach.Sum(arr: array of Integer): Integer;
+var
+  total: Integer;
+begin
+  total := 0;
+  for each item: Integer in arr do
+    total := total + item;
+  result := total;
+end;
+
+end.

--- a/tests/TypedUsing.cs
+++ b/tests/TypedUsing.cs
@@ -1,0 +1,10 @@
+namespace Demo {
+    public partial class TypedUsing {
+        public static IDisposable GetRes() {
+            return null;
+        }
+        public static void DoStuff() {
+            using (IDisposable res = GetRes()) Console.WriteLine(res);
+        }
+    }
+}

--- a/tests/TypedUsing.pas
+++ b/tests/TypedUsing.pas
@@ -1,0 +1,23 @@
+namespace Demo;
+
+type
+  TypedUsing = class
+  public
+    class method GetRes: IDisposable;
+    class method DoStuff;
+  end;
+
+implementation
+
+class method TypedUsing.GetRes: IDisposable;
+begin
+  result := nil;
+end;
+
+class method TypedUsing.DoStuff;
+begin
+  using res: IDisposable := GetRes() do
+    Console.WriteLine(res);
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -418,7 +418,7 @@ class TranspileTests(unittest.TestCase):
         expected = Path('tests/AliasDef.cs').read_text().strip()
         result, todos = transpile(src)
         self.assertEqual(result.strip(), expected)
-        self.assertEqual(todos, ["// TODO: alias MimeMappingType -> &Type"])
+        self.assertEqual(todos, [])
 
     def test_char_code(self):
         src = Path('tests/CharCode.pas').read_text()

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -385,6 +385,48 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, ["// TODO: event OnSomething: EventHandler -> implement"])
 
+    def test_field_initializer(self):
+        src = Path('tests/FieldInit.pas').read_text()
+        expected = Path('tests/FieldInit.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, ["// TODO: field Count: int -> declare a field"])
+
+    def test_typed_for_each(self):
+        src = Path('tests/TypedForEach.pas').read_text()
+        expected = Path('tests/TypedForEach.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_typed_using(self):
+        src = Path('tests/TypedUsing.pas').read_text()
+        expected = Path('tests/TypedUsing.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_typeof_and_new_array(self):
+        src = Path('tests/TypeOfNew.pas').read_text()
+        expected = Path('tests/TypeOfNew.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_alias_def(self):
+        src = Path('tests/AliasDef.pas').read_text()
+        expected = Path('tests/AliasDef.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, ["// TODO: alias MimeMappingType -> &Type"])
+
+    def test_char_code(self):
+        src = Path('tests/CharCode.pas').read_text()
+        expected = Path('tests/CharCode.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_error_reporting(self):
         src = Path('tests/BadSyntax.pas').read_text()
         with self.assertRaises(SyntaxError) as cm:

--- a/utils.py
+++ b/utils.py
@@ -19,6 +19,8 @@ def map_type_ext(typ: str) -> str:
     return map_type(typ)
 
 def fix_keyword(tok):
+    if tok.value.startswith('&'):
+        tok.value = tok.value[1:]
     v = tok.value.lower()
     if v == "and":
         tok.type = "OP_MUL"
@@ -82,4 +84,6 @@ def fix_keyword(tok):
         tok.type = "OPERATOR"
     elif v == "tuple":
         tok.type = "TUPLE"
+    elif v == "typeof":
+        tok.type = "TYPEOF"
     return tok


### PR DESCRIPTION
## Summary
- add tests covering field initializers, typed foreach/using, typeof/array creation, char codes and alias definitions
- escape char codes correctly in the transformer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517cc6978483319f24f4e8e493114b