### PR TITLE
Improve keyword handling in identifiers

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -94,6 +94,7 @@ block:       "begin" stmt* "end" ";"?
            | repeat_stmt
            | break_stmt
            | continue_stmt
+           | var_stmt
            | loop_stmt
            | using_stmt
            | locking_stmt
@@ -111,6 +112,7 @@ raise_stmt: RAISE expr? ";"?                                 -> raise_stmt
 repeat_stmt: "repeat"i stmt* "until"i expr ";"?               -> repeat_stmt
 break_stmt: BREAK ";"?                                     -> break_stmt
 continue_stmt: CONTINUE ";"?                                -> continue_stmt
+var_stmt:    "var"i var_decl+                               -> var_stmt
 using_stmt: USING CNAME (":" type_name)? ":=" expr DO stmt                  -> using_var
            | USING expr DO stmt                           -> using_expr
            | USING AUTORELEASEPOOL DO stmt                -> using_pool
@@ -140,6 +142,8 @@ inherited_stmt: "inherited" ";"?                          -> inherited
            | AT var_ref                 -> addr_of
            | expr OP_SUM   expr          -> binop
            | expr OP_MUL   expr          -> binop
+           | expr OP_SUM ELSE expr      -> short_or
+           | expr OP_MUL THEN expr      -> short_and
            | expr (OP_REL|LT|GT) expr    -> binop
            | expr IN set_lit             -> in_expr
            | expr IS type_name           -> is_inst
@@ -219,6 +223,8 @@ FINALLY:     "finally"i
 ON:          "on"i
 CASE:        "case"i
 OF:          "of"i
+THEN:        "then"i
+ELSE:        "else"i
 
 TRUE:        "true"i
 FALSE:       "false"i

--- a/pas2cs.py
+++ b/pas2cs.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from lark import Lark
 from grammar import GRAMMAR
 from transformer import ToCSharp
-from utils import fix_keyword
+from utils import fix_keyword, set_source
 
 
 def interactive_translate(rule: str, children, line: int) -> str | None:
@@ -23,6 +23,7 @@ def interactive_translate(rule: str, children, line: int) -> str | None:
 
 def transpile(source: str, manual_translate=None, manual_parse_error=None) -> tuple[str, list[str]]:
     source = source.lstrip('\ufeff')
+    set_source(source)
     parser = Lark(
         GRAMMAR,
         parser="lalr",

--- a/tests/AliasDef.cs
+++ b/tests/AliasDef.cs
@@ -1,0 +1,7 @@
+using MimeMappingType = Type;
+
+namespace Demo {
+    public partial class AliasHolder {
+    
+    }
+}

--- a/tests/AliasDef.pas
+++ b/tests/AliasDef.pas
@@ -1,0 +1,9 @@
+namespace Demo;
+
+type
+  MimeMappingType = &Type;
+
+  AliasHolder = public class
+  end;
+
+end.

--- a/tests/AsCast.cs
+++ b/tests/AsCast.cs
@@ -1,0 +1,9 @@
+namespace Demo {
+    public partial class AsExample {
+        public string CastIt(object v) {
+            string s;
+            s = v as string;
+            return s;
+        }
+    }
+}

--- a/tests/AsCast.pas
+++ b/tests/AsCast.pas
@@ -1,0 +1,19 @@
+namespace Demo;
+
+type
+  AsExample = public class
+  public
+    method CastIt(v: Object): String;
+  end;
+
+implementation
+
+method AsExample.CastIt(v: Object): String;
+var
+  s: String;
+begin
+  s := v as String;
+  result := s;
+end;
+
+end.

--- a/tests/CharCode.cs
+++ b/tests/CharCode.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class CharCodeExample {
+        public static string GetNewline() {
+            return "\r" + "\n";
+        }
+    }
+}

--- a/tests/CharCode.pas
+++ b/tests/CharCode.pas
@@ -1,0 +1,16 @@
+namespace Demo;
+
+type
+  CharCodeExample = public class
+  public
+    class method GetNewline: String;
+  end;
+
+implementation
+
+class method CharCodeExample.GetNewline: String;
+begin
+  result := #13 + #10;
+end;
+
+end.

--- a/tests/CharCodeSeq.cs
+++ b/tests/CharCodeSeq.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class CharSeq {
+        public static string GetCRLF() {
+            return "\r\n";
+        }
+    }
+}

--- a/tests/CharCodeSeq.pas
+++ b/tests/CharCodeSeq.pas
@@ -1,0 +1,16 @@
+namespace Demo;
+
+type
+  CharSeq = class
+  public
+    class method GetCRLF: String;
+  end;
+
+implementation
+
+class method CharSeq.GetCRLF: String;
+begin
+  result := #13#10;
+end;
+
+end.

--- a/tests/ClassVar.cs
+++ b/tests/ClassVar.cs
@@ -1,6 +1,6 @@
 namespace Demo {
     public partial class Logger {
         // TODO: field Log: int -> declare a field
-        public int Log;
+        public static int Log;
     }
 }

--- a/tests/ConstParam.cs
+++ b/tests/ConstParam.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class ConstParam {
+        public static string Echo(string s) {
+            return s;
+        }
+    }
+}

--- a/tests/ConstParam.pas
+++ b/tests/ConstParam.pas
@@ -1,0 +1,16 @@
+namespace Demo;
+
+type
+  ConstParam = class
+  public
+    class method Echo(const s: String): String;
+  end;
+
+implementation
+
+class method ConstParam.Echo(const s: String): String;
+begin
+  result := s;
+end;
+
+end.

--- a/tests/FieldInit.cs
+++ b/tests/FieldInit.cs
@@ -1,0 +1,6 @@
+namespace Demo {
+    public partial class FieldInit {
+        // TODO: field Count: int -> declare a field
+        public int Count = 1;
+    }
+}

--- a/tests/FieldInit.pas
+++ b/tests/FieldInit.pas
@@ -1,0 +1,9 @@
+namespace Demo;
+
+type
+  FieldInit = class
+  public
+    var Count: Integer := 1;
+  end;
+
+end.

--- a/tests/GenericMethod.cs
+++ b/tests/GenericMethod.cs
@@ -1,0 +1,6 @@
+namespace Demo {
+    public partial class GenClass {
+        public static void DeSerialize<T>(string json, T obj) {
+        }
+    }
+}

--- a/tests/GenericMethod.pas
+++ b/tests/GenericMethod.pas
@@ -1,0 +1,15 @@
+namespace Demo;
+
+type
+  GenClass = public class
+  public
+    class procedure DeSerialize<T>(json: String; var obj: T);
+  end;
+
+implementation
+
+class procedure GenClass.DeSerialize<T>(json: String; var obj: T);
+begin
+end;
+
+end.

--- a/tests/IsOp.cs
+++ b/tests/IsOp.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class IsExample {
+        public static void Check(object o) {
+            if (o is string) o = null;
+        }
+    }
+}

--- a/tests/IsOp.pas
+++ b/tests/IsOp.pas
@@ -1,0 +1,17 @@
+namespace Demo;
+
+type
+  IsExample = class
+  public
+    class method Check(o: Object);
+  end;
+
+implementation
+
+class method IsExample.Check(o: Object);
+begin
+  if o is String then
+    o := nil;
+end;
+
+end.

--- a/tests/KeywordName.cs
+++ b/tests/KeywordName.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Demo {
+    public partial class KeywordName {
+        public void DoStuff(MailMessage mail) {
+            object x = Enum.Parse(typeof(int), "1");
+            mail.To.Clear();
+        }
+    }
+}

--- a/tests/KeywordName.pas
+++ b/tests/KeywordName.pas
@@ -1,0 +1,19 @@
+namespace Demo;
+
+type
+  KeywordName = public class
+  public
+    method DoStuff(mail: MailMessage);
+  end;
+
+implementation
+uses System;
+
+method KeywordName.DoStuff(mail: MailMessage);
+var
+  x : Object := Enum.Parse(typeof(Integer), '1');
+begin
+  mail.To.Clear();
+end;
+
+end.

--- a/tests/ReservedProp.cs
+++ b/tests/ReservedProp.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class ReservedProp {
+        public void Send(MailMessage mail, string emailTo) {
+            mail.To = emailTo;
+        }
+    }
+}

--- a/tests/ReservedProp.pas
+++ b/tests/ReservedProp.pas
@@ -1,0 +1,16 @@
+namespace Demo;
+
+type
+  ReservedProp = public class
+  public
+    method Send(mail: MailMessage; emailTo: String);
+  end;
+
+implementation
+
+method ReservedProp.Send(mail: MailMessage; emailTo: String);
+begin
+  mail.&To := emailTo;
+end;
+
+end.

--- a/tests/ShortCircuit.cs
+++ b/tests/ShortCircuit.cs
@@ -1,0 +1,8 @@
+namespace Demo {
+    public partial class ShortCircuit {
+        public void Check(bool a, bool b) {
+            if (a || b) Console.WriteLine("yes");
+            if (a && b) Console.WriteLine("and");
+        }
+    }
+}

--- a/tests/ShortCircuit.pas
+++ b/tests/ShortCircuit.pas
@@ -1,0 +1,19 @@
+namespace Demo;
+
+type
+  ShortCircuit = public class
+  public
+    method Check(a: Boolean; b: Boolean);
+  end;
+
+implementation
+
+method ShortCircuit.Check(a: Boolean; b: Boolean);
+begin
+  if a or else b then
+    Console.WriteLine('yes');
+  if a and then b then
+    Console.WriteLine('and');
+end;
+
+end.

--- a/tests/TypeOfNew.cs
+++ b/tests/TypeOfNew.cs
@@ -1,0 +1,10 @@
+namespace Demo {
+    public partial class TypeOfNew {
+        public static Byte[] MakeArray(int len) {
+            return new Byte[len];
+        }
+        public static void Show() {
+            Console.WriteLine(typeof(int));
+        }
+    }
+}

--- a/tests/TypeOfNew.pas
+++ b/tests/TypeOfNew.pas
@@ -1,0 +1,22 @@
+namespace Demo;
+
+type
+  TypeOfNew = class
+  public
+    class method MakeArray(len: Integer): array of Byte;
+    class method Show;
+  end;
+
+implementation
+
+class method TypeOfNew.MakeArray(len: Integer): array of Byte;
+begin
+  result := new Byte[len];
+end;
+
+class method TypeOfNew.Show;
+begin
+  Console.WriteLine(typeof(Integer));
+end;
+
+end.

--- a/tests/TypeOfPostfix.cs
+++ b/tests/TypeOfPostfix.cs
@@ -1,0 +1,9 @@
+using LogManager;
+
+namespace Demo {
+    public partial class Example {
+        public static void Test() {
+            LogManager.GetLogger(typeof(Example).ToString);
+        }
+    }
+}

--- a/tests/TypeOfPostfix.pas
+++ b/tests/TypeOfPostfix.pas
@@ -1,0 +1,20 @@
+namespace Demo;
+
+interface
+
+uses LogManager;
+
+type
+  Example = public class
+  public
+    class method Test;
+  end;
+
+implementation
+
+class method Example.Test;
+begin
+  LogManager.GetLogger(typeof(Example).ToString);
+end;
+
+end.

--- a/tests/TypedForEach.cs
+++ b/tests/TypedForEach.cs
@@ -1,0 +1,10 @@
+namespace Demo {
+    public partial class TypedForEach {
+        public static int Sum(int[] arr) {
+            int total;
+            total = 0;
+            foreach (int item in arr) total = total + item;
+            return total;
+        }
+    }
+}

--- a/tests/TypedForEach.pas
+++ b/tests/TypedForEach.pas
@@ -1,0 +1,21 @@
+namespace Demo;
+
+type
+  TypedForEach = class
+  public
+    class method Sum(arr: array of Integer): Integer;
+  end;
+
+implementation
+
+class method TypedForEach.Sum(arr: array of Integer): Integer;
+var
+  total: Integer;
+begin
+  total := 0;
+  for each item: Integer in arr do
+    total := total + item;
+  result := total;
+end;
+
+end.

--- a/tests/TypedForLoop.cs
+++ b/tests/TypedForLoop.cs
@@ -1,0 +1,10 @@
+namespace Demo {
+    public partial class TypedForLoop {
+        public static int Sum(int[] arr) {
+            int total;
+            total = 0;
+            for (int i = 0; i <= length(arr) - 1; i++) total = total + arr[i];
+            return total;
+        }
+    }
+}

--- a/tests/TypedForLoop.pas
+++ b/tests/TypedForLoop.pas
@@ -1,0 +1,21 @@
+namespace Demo;
+
+type
+  TypedForLoop = class
+  public
+    class method Sum(arr: array of Integer): Integer;
+  end;
+
+implementation
+
+class method TypedForLoop.Sum(arr: array of Integer): Integer;
+var
+  total: Integer;
+begin
+  total := 0;
+  for i: Integer := 0 to length(arr) - 1 do
+    total := total + arr[i];
+  result := total;
+end;
+
+end.

--- a/tests/TypedUsing.cs
+++ b/tests/TypedUsing.cs
@@ -1,0 +1,10 @@
+namespace Demo {
+    public partial class TypedUsing {
+        public static IDisposable GetRes() {
+            return null;
+        }
+        public static void DoStuff() {
+            using (IDisposable res = GetRes()) Console.WriteLine(res);
+        }
+    }
+}

--- a/tests/TypedUsing.pas
+++ b/tests/TypedUsing.pas
@@ -1,0 +1,23 @@
+namespace Demo;
+
+type
+  TypedUsing = class
+  public
+    class method GetRes: IDisposable;
+    class method DoStuff;
+  end;
+
+implementation
+
+class method TypedUsing.GetRes: IDisposable;
+begin
+  result := nil;
+end;
+
+class method TypedUsing.DoStuff;
+begin
+  using res: IDisposable := GetRes() do
+    Console.WriteLine(res);
+end;
+
+end.

--- a/tests/VarStmt.cs
+++ b/tests/VarStmt.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class VarStmt {
+        public void Example() {
+            string delimiter = ",";
+        }
+    }
+}

--- a/tests/VarStmt.pas
+++ b/tests/VarStmt.pas
@@ -1,0 +1,16 @@
+namespace Demo;
+
+type
+  VarStmt = public class
+  public
+    method Example;
+  end;
+
+implementation
+
+method VarStmt.Example;
+begin
+  var delimiter : String := ',';
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -434,6 +434,20 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_var_stmt(self):
+        src = Path('tests/VarStmt.pas').read_text()
+        expected = Path('tests/VarStmt.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_short_circuit(self):
+        src = Path('tests/ShortCircuit.pas').read_text()
+        expected = Path('tests/ShortCircuit.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_typeof_postfix(self):
         src = Path('tests/TypeOfPostfix.pas').read_text()
         expected = Path('tests/TypeOfPostfix.cs').read_text().strip()

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -385,6 +385,111 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, ["// TODO: event OnSomething: EventHandler -> implement"])
 
+    def test_field_initializer(self):
+        src = Path('tests/FieldInit.pas').read_text()
+        expected = Path('tests/FieldInit.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, ["// TODO: field Count: int -> declare a field"])
+
+    def test_typed_for_each(self):
+        src = Path('tests/TypedForEach.pas').read_text()
+        expected = Path('tests/TypedForEach.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_typed_using(self):
+        src = Path('tests/TypedUsing.pas').read_text()
+        expected = Path('tests/TypedUsing.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_typeof_and_new_array(self):
+        src = Path('tests/TypeOfNew.pas').read_text()
+        expected = Path('tests/TypeOfNew.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_alias_def(self):
+        src = Path('tests/AliasDef.pas').read_text()
+        expected = Path('tests/AliasDef.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_char_code(self):
+        src = Path('tests/CharCode.pas').read_text()
+        expected = Path('tests/CharCode.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_char_code_seq(self):
+        src = Path('tests/CharCodeSeq.pas').read_text()
+        expected = Path('tests/CharCodeSeq.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_typeof_postfix(self):
+        src = Path('tests/TypeOfPostfix.pas').read_text()
+        expected = Path('tests/TypeOfPostfix.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_typed_for_loop(self):
+        src = Path('tests/TypedForLoop.pas').read_text()
+        expected = Path('tests/TypedForLoop.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_const_param(self):
+        src = Path('tests/ConstParam.pas').read_text()
+        expected = Path('tests/ConstParam.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_is_operator(self):
+        src = Path('tests/IsOp.pas').read_text()
+        expected = Path('tests/IsOp.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_generic_method(self):
+        src = Path('tests/GenericMethod.pas').read_text()
+        expected = Path('tests/GenericMethod.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_as_cast(self):
+        src = Path('tests/AsCast.pas').read_text()
+        expected = Path('tests/AsCast.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_reserved_prop(self):
+        src = Path('tests/ReservedProp.pas').read_text()
+        expected = Path('tests/ReservedProp.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_keyword_name(self):
+        src = Path('tests/KeywordName.pas').read_text()
+        expected = Path('tests/KeywordName.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_error_reporting(self):
         src = Path('tests/BadSyntax.pas').read_text()
         with self.assertRaises(SyntaxError) as cm:

--- a/transformer.py
+++ b/transformer.py
@@ -362,6 +362,9 @@ class ToCSharp(Transformer):
     def var_section(self, *decls):
         return "\n".join(decls)
 
+    def var_stmt(self, *decls):
+        return "\n".join(decls)
+
     def var_decl(self, names, typ, expr=None):
         t = map_type_ext(str(typ))
         decl = f"{t} {', '.join(names)}"
@@ -673,8 +676,22 @@ class ToCSharp(Transformer):
 
     # ── expressions ─────────────────────────────────────────
     def binop(self, left, op, right):
-        op_map = {"and": "&&", "or": "||", "<>": "!=", "=": "==", "mod": "%"}
+        op_map = {
+            "and": "&&",
+            "or": "||",
+            "and then": "&&",
+            "or else": "||",
+            "<>": "!=",
+            "=": "==",
+            "mod": "%",
+        }
         return f"{left} {op_map.get(op, op)} {right}"
+
+    def short_or(self, left, _or, _else, right):
+        return self.binop(left, "or else", right)
+
+    def short_and(self, left, _and, _then, right):
+        return self.binop(left, "and then", right)
 
     def not_expr(self, _tok, expr):
         return f"!{expr}"


### PR DESCRIPTION
## Summary
- keep reserved words when used as identifiers after a dot
- plumb source text to `fix_keyword` for context
- add regression covering `Enum.Parse` and property `To`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68517cc6978483319f24f4e8e493114b