### PR TITLE
Add grammar support and tests

### DIFF
--- a/tests/AsCastCall.cs
+++ b/tests/AsCastCall.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class AsCastCall {
+        public void Update(object adapter, object ds, string name) {
+            (adapter as DB2DataAdapter).Update(ds, name);
+        }
+    }
+}

--- a/tests/AsCastCall.pas
+++ b/tests/AsCastCall.pas
@@ -1,0 +1,16 @@
+namespace Demo;
+
+type
+  AsCastCall = public class
+  public
+    method Update(adapter: Object; ds: Object; name: String);
+  end;
+
+implementation
+
+method AsCastCall.Update(adapter: Object; ds: Object; name: String);
+begin
+  (adapter as DB2DataAdapter).Update(ds, name);
+end;
+
+end.

--- a/tests/InheritedCall.cs
+++ b/tests/InheritedCall.cs
@@ -1,0 +1,14 @@
+namespace Demo {
+    public partial class Base {
+        public int Foo(int a) {
+            return a;
+        }
+    }
+    
+    public partial class Derived : Base {
+        public int Foo(int a) {
+            var request = base.Foo(a);
+            return request;
+        }
+    }
+}

--- a/tests/InheritedCall.pas
+++ b/tests/InheritedCall.pas
@@ -1,0 +1,27 @@
+namespace Demo;
+
+type
+  Base = public class
+  public
+    method Foo(a: Integer): Integer; virtual;
+  end;
+
+  Derived = public class(Base)
+  public
+    method Foo(a: Integer): Integer; override;
+  end;
+
+implementation
+
+method Base.Foo(a: Integer): Integer;
+begin
+  result := a;
+end;
+
+method Derived.Foo(a: Integer): Integer;
+var request := inherited Foo(a);
+begin
+  result := request;
+end;
+
+end.

--- a/tests/NotInExpr.cs
+++ b/tests/NotInExpr.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class NotIn {
+        public void Check(string tipo) {
+            if (!System.Array.Exists(new[]{"Aluno", "Funcionario"}, x => x == tipo)) Console.WriteLine("nao");
+        }
+    }
+}

--- a/tests/NotInExpr.pas
+++ b/tests/NotInExpr.pas
@@ -1,0 +1,17 @@
+namespace Demo;
+
+type
+  NotIn = public class
+  public
+    method Check(tipo: String);
+  end;
+
+implementation
+
+method NotIn.Check(tipo: String);
+begin
+  if tipo not in ['Aluno', 'Funcionario'] then
+    Console.WriteLine('nao');
+end;
+
+end.

--- a/tests/VarInfer.cs
+++ b/tests/VarInfer.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class VarInfer {
+        public void Example() {
+            var cli = new WebClient();
+        }
+    }
+}

--- a/tests/VarInfer.pas
+++ b/tests/VarInfer.pas
@@ -1,0 +1,16 @@
+namespace Demo;
+
+type
+  VarInfer = public class
+  public
+    method Example;
+  end;
+
+implementation
+
+method VarInfer.Example;
+begin
+  var cli := new WebClient();
+end;
+
+end.

--- a/tests/test_user_parse_errors.py
+++ b/tests/test_user_parse_errors.py
@@ -1,0 +1,23 @@
+import unittest
+from pathlib import Path
+from pas2cs import transpile
+
+class NewFeatureTests(unittest.TestCase):
+    def check_pair(self, name: str):
+        src = Path(f'tests/{name}.pas').read_text()
+        expected = Path(f'tests/{name}.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_var_infer(self):
+        self.check_pair('VarInfer')
+
+    def test_not_in_expr(self):
+        self.check_pair('NotInExpr')
+
+    def test_as_cast_call(self):
+        self.check_pair('AsCastCall')
+
+    def test_inherited_call(self):
+        self.check_pair('InheritedCall')


### PR DESCRIPTION
## Summary
- support var inference, inherited method calls and not-in expressions
- allow method calls on parenthesized expressions
- add tests covering new grammar features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6851a2a7d298833198aa17ce665cbc82