### PR TITLE
Support '+=' and '-=' assignments

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -83,6 +83,7 @@ impl_head:   method_name param_block? return_block?
 block:       "begin" stmt* "end" ";"?
 
 ?stmt:       assign_stmt
+           | op_assign_stmt
            | return_stmt
            | if_stmt
            | for_stmt
@@ -106,6 +107,8 @@ block:       "begin" stmt* "end" ";"?
             |                         -> empty
 
 assign_stmt: var_ref ":=" expr ";"?                              -> assign
+op_assign_stmt: var_ref ADD_ASSIGN expr ";"?                -> op_assign
+               | var_ref SUB_ASSIGN expr ";"?                -> op_assign
 return_stmt: RESULT ":=" expr ";"?                             -> result_ret
             | EXIT expr? ";"?                                  -> exit_ret
 raise_stmt: RAISE expr? ";"?                                 -> raise_stmt
@@ -204,6 +207,8 @@ GENERIC_ARGS: /<(?:(?:[^<>]|<[^<>]*>)+)>/
 OP_SUM:      "+" | "-" | "or"
 OP_MUL:      "*" | "/" | "and" | "mod"i
 OP_REL:      "=" | "<>" | "<=" | ">="
+ADD_ASSIGN.2:  "+="
+SUB_ASSIGN.2:  "-="
 
 NOT:         "not"i
 

--- a/tests/OpAssign.cs
+++ b/tests/OpAssign.cs
@@ -1,0 +1,10 @@
+namespace Demo {
+    public partial class OpAssign {
+        public void Example() {
+            int x;
+            x = 5;
+            x += 2;
+            x -= 1;
+        }
+    }
+}

--- a/tests/OpAssign.pas
+++ b/tests/OpAssign.pas
@@ -1,0 +1,20 @@
+namespace Demo;
+
+type
+  OpAssign = public class
+  public
+    method Example;
+  end;
+
+implementation
+
+method OpAssign.Example;
+var
+  x: Integer;
+begin
+  x := 5;
+  x += 2;
+  x -= 1;
+end;
+
+end.

--- a/tests/test_user_parse_errors.py
+++ b/tests/test_user_parse_errors.py
@@ -28,3 +28,6 @@ class NewFeatureTests(unittest.TestCase):
 
     def test_property_assign(self):
         self.check_pair('PropertyAssign', allow_todos=True)
+
+    def test_op_assign(self):
+        self.check_pair('OpAssign')

--- a/transformer.py
+++ b/transformer.py
@@ -515,6 +515,9 @@ class ToCSharp(Transformer):
     def assign(self, var, expr):
         return f"{var} = {expr};"
 
+    def op_assign(self, var, op, expr):
+        return f"{var} {op} {expr};"
+
     def result_ret(self, _tok, expr):
         return f"return {expr};"
 


### PR DESCRIPTION
## Summary
- extend statement grammar with `op_assign_stmt` for operator assignment
- add `ADD_ASSIGN` and `SUB_ASSIGN` tokens with high priority
- implement `op_assign` in transformer

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851b3f73e288331bfb6fc1e262a2e92