### PR TITLE
Add named argument support

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -194,7 +194,9 @@ call_expr:   var_ref "(" arg_list? ")" call_postfix*     -> call
            | "(" expr ")" "." name_term ("(" arg_list? ")")? call_postfix* -> call
            | "inherited"i name_term ("(" arg_list? ")")? call_postfix*        -> inherited_call_expr
            | typeof_expr call_postfix+                   -> call
-arg_list:    expr ("," expr)*
+arg_list:    arg ("," arg)*
+arg:         CNAME ":=" expr                -> named_arg
+           | expr
 
 var_ref:     name_base (ARRAY_RANGE | "." name_term)*   -> var
 

--- a/tests/NamedArg.cs
+++ b/tests/NamedArg.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Demo {
+    public partial class NamedArg {
+        public void UseArgs() {
+            Console.WriteLine(123, "ok");
+        }
+    }
+}

--- a/tests/NamedArg.pas
+++ b/tests/NamedArg.pas
@@ -1,0 +1,20 @@
+namespace Demo;
+
+interface
+
+uses System;
+
+type
+  NamedArg = public class
+  public
+    procedure UseArgs;
+  end;
+
+implementation
+
+procedure NamedArg.UseArgs;
+begin
+  Console.WriteLine(value := 123, message := 'ok');
+end;
+
+end.

--- a/tests/test_user_parse_errors.py
+++ b/tests/test_user_parse_errors.py
@@ -31,3 +31,6 @@ class NewFeatureTests(unittest.TestCase):
 
     def test_op_assign(self):
         self.check_pair('OpAssign')
+
+    def test_named_arg(self):
+        self.check_pair('NamedArg')

--- a/transformer.py
+++ b/transformer.py
@@ -157,13 +157,10 @@ class ToCSharp(Transformer):
         inner = ', '.join(types)
         return f"System.ValueTuple<{inner}>"
 
-    def generic_params(self, _lt, first, *rest):
-        names = [str(first)]
-        for item in rest:
-            if isinstance(item, Token) and item.type == ',':
-                continue
-            names.append(str(item))
-        return '<' + ', '.join(names) + '>'
+    def generic_params(self, *names):
+        # grammar only yields the parameter identifiers
+        cleaned = [str(n) for n in names]
+        return '<' + ', '.join(cleaned) + '>'
 
     def _add_type(self, cname, kind, base, sign_list):
         self.class_defs[str(cname)] = (kind, base, sign_list)
@@ -362,6 +359,12 @@ class ToCSharp(Transformer):
 
     def arg_list(self, *args):
         return list(args)
+
+    def arg(self, value):
+        return value
+
+    def named_arg(self, name, expr):
+        return expr
 
     def method_decl(self, *parts):
         for p in parts:


### PR DESCRIPTION
## Summary
- support named arguments in call expressions by updating grammar
- implement transformer handlers for named args
- parse generic parameters correctly
- add NamedArg sample and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851d0d7413c8331a9c7f0451acbae30