### PR TITLE
Support multiple base types in class definitions

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -17,7 +17,7 @@ type_def:    attributes? class_def
            | attributes? enum_def
            | alias_def
 
-class_def:   CNAME generic_params? "=" ("public"i)? "static"? "partial"? "abstract"? "class"i ("(" type_name ")")? class_signature "end"i ";" -> class_def
+class_def:   CNAME generic_params? "=" ("public"i)? "static"? "partial"? "abstract"? "class"i ("(" type_name ("," type_name)* ")")? class_signature "end"i ";" -> class_def
 record_def:  CNAME generic_params? "=" ("public"i)? "record"i ("(" type_name ")")? class_signature "end"i ";" -> record_def
 interface_def: CNAME generic_params? "=" ("public"i)? "interface"i ("(" type_name ("," type_name)* ")")? class_signature "end"i ";" -> interface_def
 enum_def:    CNAME "=" ("public"i)? ("enum"i | "flags"i)? "(" enum_items ")" ("of" type_name)? ";" -> enum_def

--- a/tests/MultiBase.cs
+++ b/tests/MultiBase.cs
@@ -1,0 +1,15 @@
+namespace Demo {
+    public partial class BaseCls {
+        public void BaseMethod() {
+        }
+    }
+    
+    public partial class Child : BaseCls, IFoo, IBar {
+        public void BaseMethod() {
+        }
+        public void Foo() {
+        }
+        public void Bar() {
+        }
+    }
+}

--- a/tests/MultiBase.pas
+++ b/tests/MultiBase.pas
@@ -1,0 +1,34 @@
+namespace Demo;
+
+type
+  BaseCls = public class
+  public
+    method BaseMethod;
+  end;
+
+  Child = public class(BaseCls, IFoo, IBar)
+  public
+    method BaseMethod;
+    method Foo;
+    method Bar;
+  end;
+
+implementation
+
+method BaseCls.BaseMethod;
+begin
+end;
+
+method Child.BaseMethod;
+begin
+end;
+
+method Child.Foo;
+begin
+end;
+
+method Child.Bar;
+begin
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -316,6 +316,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_multi_base(self):
+        src = Path('tests/MultiBase.pas').read_text()
+        expected = Path('tests/MultiBase.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_event_operator(self):
         src = Path('tests/EventOperator.pas').read_text()
         expected = Path('tests/EventOperator.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -175,14 +175,13 @@ class ToCSharp(Transformer):
         if parts and isinstance(parts[0], str) and parts[0].startswith('<'):
             generics = parts[0]
             parts = parts[1:]
-        if len(parts) == 2:
-            base, sign = parts
-        else:
-            sign = parts[0]
-            base = None
+        sign = parts[-1]
+        bases = list(parts[:-1]) if len(parts) > 1 else []
         prev = getattr(self, "curr_class", None)
         self.curr_class = str(cname) + generics
-        base_cs = f" : {map_type_ext(str(base))}" if base else ""
+        base_cs = ""
+        if bases:
+            base_cs = " : " + ", ".join(map_type_ext(str(b)) for b in bases)
         sign_list = sign if isinstance(sign, list) else []
         name_full = str(cname) + generics
         self._add_type(name_full, "class", base_cs, sign_list)


### PR DESCRIPTION
## Summary
- allow multiple types in `class_def` grammar rule
- output all base types for a class in the transformer
- add new test covering class inheritance with multiple interfaces

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851d9e6d4248331abe9ee9cd0408a17