### PR TITLE
Support sealed class modifier

### DIFF
--- a/tests/ArrayCast.cs
+++ b/tests/ArrayCast.cs
@@ -1,0 +1,8 @@
+namespace Demo {
+    public partial class ArrayCast {
+        public static void Create() {
+            int[] arr;
+            arr = new int[]{1, 2, 3};
+        }
+    }
+}

--- a/tests/ArrayCast.pas
+++ b/tests/ArrayCast.pas
@@ -1,0 +1,18 @@
+namespace Demo;
+
+type
+  ArrayCast = class
+  public
+    class method Create;
+  end;
+
+implementation
+
+class method ArrayCast.Create;
+var
+  arr: array of Integer;
+begin
+  arr := array of Integer([1, 2, 3]);
+end;
+
+end.

--- a/tests/MultiBase.cs
+++ b/tests/MultiBase.cs
@@ -1,0 +1,15 @@
+namespace Demo {
+    public partial class BaseCls {
+        public void BaseMethod() {
+        }
+    }
+    
+    public partial class Child : BaseCls, IFoo, IBar {
+        public void BaseMethod() {
+        }
+        public void Foo() {
+        }
+        public void Bar() {
+        }
+    }
+}

--- a/tests/MultiBase.pas
+++ b/tests/MultiBase.pas
@@ -1,0 +1,34 @@
+namespace Demo;
+
+type
+  BaseCls = public class
+  public
+    method BaseMethod;
+  end;
+
+  Child = public class(BaseCls, IFoo, IBar)
+  public
+    method BaseMethod;
+    method Foo;
+    method Bar;
+  end;
+
+implementation
+
+method BaseCls.BaseMethod;
+begin
+end;
+
+method Child.BaseMethod;
+begin
+end;
+
+method Child.Foo;
+begin
+end;
+
+method Child.Bar;
+begin
+end;
+
+end.

--- a/tests/NamedArg.cs
+++ b/tests/NamedArg.cs
@@ -1,0 +1,9 @@
+using System;
+
+namespace Demo {
+    public partial class NamedArg {
+        public void UseArgs() {
+            Console.WriteLine(123, "ok");
+        }
+    }
+}

--- a/tests/NamedArg.pas
+++ b/tests/NamedArg.pas
@@ -1,0 +1,20 @@
+namespace Demo;
+
+interface
+
+uses System;
+
+type
+  NamedArg = public class
+  public
+    procedure UseArgs;
+  end;
+
+implementation
+
+procedure NamedArg.UseArgs;
+begin
+  Console.WriteLine(value := 123, message := 'ok');
+end;
+
+end.

--- a/tests/NewStmt.cs
+++ b/tests/NewStmt.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class NewStmt {
+        public static void Make() {
+            new Exception("fail");
+        }
+    }
+}

--- a/tests/NewStmt.pas
+++ b/tests/NewStmt.pas
@@ -1,0 +1,16 @@
+namespace Demo;
+
+type
+  NewStmt = class
+  public
+    class method Make;
+  end;
+
+implementation
+
+class method NewStmt.Make;
+begin
+  new Exception('fail');
+end;
+
+end.

--- a/tests/SealedClass.cs
+++ b/tests/SealedClass.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class SealedClass {
+        public void DoStuff() {
+        }
+    }
+}
+

--- a/tests/SealedClass.pas
+++ b/tests/SealedClass.pas
@@ -1,0 +1,14 @@
+namespace Demo;
+
+type
+  SealedClass = public class sealed
+  public
+    procedure DoStuff;
+  end;
+
+implementation
+
+procedure SealedClass.DoStuff;
+begin
+end;
+

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -316,6 +316,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_multi_base(self):
+        src = Path('tests/MultiBase.pas').read_text()
+        expected = Path('tests/MultiBase.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_event_operator(self):
         src = Path('tests/EventOperator.pas').read_text()
         expected = Path('tests/EventOperator.cs').read_text().strip()
@@ -411,6 +418,27 @@ class TranspileTests(unittest.TestCase):
     def test_keyword_name(self):
         src = Path('tests/KeywordName.pas').read_text()
         expected = Path('tests/KeywordName.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_sealed_class(self):
+        src = Path('tests/SealedClass.pas').read_text()
+        expected = Path('tests/SealedClass.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_new_stmt(self):
+        src = Path('tests/NewStmt.pas').read_text()
+        expected = Path('tests/NewStmt.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_array_cast(self):
+        src = Path('tests/ArrayCast.pas').read_text()
+        expected = Path('tests/ArrayCast.cs').read_text().strip()
         result, todos = transpile(src)
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])

--- a/tests/test_user_parse_errors.py
+++ b/tests/test_user_parse_errors.py
@@ -31,3 +31,6 @@ class NewFeatureTests(unittest.TestCase):
 
     def test_op_assign(self):
         self.check_pair('OpAssign')
+
+    def test_named_arg(self):
+        self.check_pair('NamedArg')

--- a/utils.py
+++ b/utils.py
@@ -4,14 +4,15 @@ def indent(code: str, lvl: int = 1) -> str:
     return textwrap.indent(code, "    " * lvl, lambda _: True)
 
 def map_type(pas_type: str) -> str:
+    """Map basic Pascal type names to their C# equivalents."""
     simple = pas_type.split('.')[-1]
     mapping = {
-        "Integer": "int",
-        "String": "string",
-        "Boolean": "bool",
-        "Object": "object",
+        "integer": "int",
+        "string": "string",
+        "boolean": "bool",
+        "object": "object",
     }
-    return mapping.get(simple, pas_type)
+    return mapping.get(simple.lower(), pas_type)
 
 def map_type_ext(typ: str) -> str:
     if typ.endswith('[]'):


### PR DESCRIPTION
## Summary
- allow `sealed` or other modifiers after the `class` keyword
- ignore unknown modifiers when producing C#
- add new statement rule to allow constructor calls as standalone statements
- handle `array of T([...])` expressions
- map Pascal types case-insensitively
- parse inline `var` declarations correctly
- add tests for new statement and array cast

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851d9e8206c833198192ec1e5f598aa