### PR TITLE
Support overload modifier and dataset row count example

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -36,7 +36,7 @@ member_decl: attributes? method_decl_rule
 method_decl_rule: access_modifier? class_modifier? method_kind method_sig ";" (method_attr ";"?)* -> method_decl
 
 class_modifier: "class"
-method_attr: "override" | "static" | "abstract" | "virtual" | "reintroduce"i
+method_attr: "override" | "static" | "abstract" | "virtual" | "reintroduce"i | "overload"i
 method_kind: METHOD | PROCEDURE | FUNCTION | CONSTRUCTOR | DESTRUCTOR | OPERATOR
 access_modifier: "public"i | "protected"i | "private"i
 
@@ -174,11 +174,14 @@ inherited_stmt: "inherited"i (name_term ("(" arg_list? ")" call_postfix*)?)? ";"
            | set_lit
            | array_of_expr
            | new_expr
+           | anon_proc_expr
            | CHAR_CODE                               -> char_code
            | expr CARET                              -> deref
 
 lambda_expr: lambda_sig ("=>" ( block | expr ) | "->" ( block | expr )) -> lambda_expr
 lambda_sig: "(" param_list? ")"
+
+anon_proc_expr: (PROCEDURE | FUNCTION) param_block? return_block? ";"? block -> anon_proc
 
 set_lit: "[" (expr ("," expr)*)? "]"
 

--- a/tests/AnonProc.cs
+++ b/tests/AnonProc.cs
@@ -1,0 +1,12 @@
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace Demo {
+    public partial class TaskExample {
+        public static void Run() {
+            Task.Factory.StartNew(() => {
+                Thread.Sleep(3000);
+            });
+        }
+    }
+}

--- a/tests/AnonProc.pas
+++ b/tests/AnonProc.pas
@@ -1,0 +1,22 @@
+namespace Demo;
+
+interface
+
+uses System.Threading.Tasks, System.Threading;
+
+type
+  TaskExample = public class
+  public
+    class method Run;
+  end;
+
+implementation
+
+class method TaskExample.Run;
+begin
+  Task.Factory.StartNew(procedure(); begin
+    Thread.Sleep(3000);
+  end);
+end;
+
+end.

--- a/tests/OverloadAttr.cs
+++ b/tests/OverloadAttr.cs
@@ -1,0 +1,8 @@
+namespace Demo {
+    public partial class OverloadExample {
+        public static void Rename(string pathOriginal) {
+        }
+        public static void Rename(string pathOriginal, string pathNova) {
+        }
+    }
+}

--- a/tests/OverloadAttr.pas
+++ b/tests/OverloadAttr.pas
@@ -1,0 +1,20 @@
+namespace Demo;
+
+type
+  OverloadExample = public class
+  public
+    class method Rename(pathOriginal: String); overload;
+    class method Rename(pathOriginal, pathNova: String); overload;
+  end;
+
+implementation
+
+class method OverloadExample.Rename(pathOriginal: String);
+begin
+end;
+
+class method OverloadExample.Rename(pathOriginal, pathNova: String);
+begin
+end;
+
+end.

--- a/tests/StringCast.cs
+++ b/tests/StringCast.cs
@@ -4,6 +4,11 @@ namespace Demo {
     public partial class CastExample {
         public static void Run(DataSet ds) {
             ((string)ds.Tables[0].Rows[1].Item["COD"]).Trim();
+            if (ds.Tables[0].Rows.Count > 10000) {
+                log.Error("QUERY COM LINHAS ACIMA DO NORMAL");
+                log.Error("QUERY STRING:" + sql);
+                log.Error("LINHAS DA QUERY: \"" + ds.Tables[0].Rows.Count.ToString + "\"");
+            }
         }
     }
 }

--- a/tests/StringCast.pas
+++ b/tests/StringCast.pas
@@ -15,6 +15,12 @@ implementation
 class method CastExample.Run(ds: DataSet);
 begin
   string(ds.Tables[0].Rows[1].Item['COD']).Trim();
+  if ds.Tables[0].Rows.Count > 10000 then
+  begin
+    log.Error('QUERY COM LINHAS ACIMA DO NORMAL');
+    log.Error('QUERY STRING:' + sql);
+    log.Error('LINHAS DA QUERY: "' + ds.Tables[0].Rows.Count.ToString + '"');
+  end;
 end;
 
 end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -205,6 +205,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_overload_attr(self):
+        src = Path('tests/OverloadAttr.pas').read_text()
+        expected = Path('tests/OverloadAttr.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_case_stmt(self):
         src = Path('tests/CaseStmt.pas').read_text()
         expected = Path('tests/CaseStmt.cs').read_text().strip()
@@ -438,6 +445,13 @@ class TranspileTests(unittest.TestCase):
     def test_lambda(self):
         src = Path('tests/Lambda.pas').read_text()
         expected = Path('tests/Lambda.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_anon_proc(self):
+        src = Path('tests/AnonProc.pas').read_text()
+        expected = Path('tests/AnonProc.cs').read_text().strip()
         result, todos = transpile(src)
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])

--- a/transformer.py
+++ b/transformer.py
@@ -978,6 +978,11 @@ class ToCSharp(Transformer):
     def lambda_expr(self, sig, body):
         return f"{sig} => {body}"
 
+    def anon_proc(self, _kind, params=None, block=None):
+        # Anonymous procedure or function converted to a lambda
+        sig = self.lambda_sig(params)
+        return f"{sig} => {block}"
+
     def char_code(self, tok):
         nums = [int(n) for n in tok.value[1:].split('#') if n]
         chars = []


### PR DESCRIPTION
## Summary
- allow `overload` as a method attribute in the grammar
- add regression test demonstrating chained dataset access in an `if` statement
- add tests for overload method declarations
- add support for anonymous procedure expressions

## Testing
- `pip install lark-parser`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b6ed50848331a3f8873f67ecc214