### PR TITLE
Fix parsing of multiple type sections

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -1,6 +1,6 @@
 # ────────────────────────── Grammar ──────────────────────────
 GRAMMAR = r"""
-?start:   namespace interface_section? class_section ("implementation" uses_clause? class_impl*)? ("end" ".")?
+?start:   namespace interface_section? class_section+ ("implementation" uses_clause? class_impl*)? ("end" ".")?
 
 interface_section: "interface" uses_clause? pre_class_decl*
 uses_clause:   "uses" dotted_name ("," dotted_name)* ";"       -> uses

--- a/teste.pas
+++ b/teste.pas
@@ -1,0 +1,15 @@
+namespace Demo;
+
+type
+  Dummy = class
+  public
+    class method Hello;
+  end;
+
+implementation
+
+class method Dummy.Hello;
+begin
+end;
+
+end.

--- a/tests/MultiTypeSections.cs
+++ b/tests/MultiTypeSections.cs
@@ -1,0 +1,11 @@
+namespace Multi {
+    public partial class First {
+        public static void Foo() {
+        }
+    }
+    
+    public partial class Second {
+        public static void Bar() {
+        }
+    }
+}

--- a/tests/MultiTypeSections.pas
+++ b/tests/MultiTypeSections.pas
@@ -1,0 +1,25 @@
+namespace Multi;
+
+type
+  First = public class
+  public
+    class method Foo;
+  end;
+
+type
+  Second = public class
+  public
+    class method Bar;
+  end;
+
+implementation
+
+class method First.Foo;
+begin
+end;
+
+class method Second.Bar;
+begin
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -477,6 +477,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_multi_type_sections(self):
+        src = Path('tests/MultiTypeSections.pas').read_text()
+        expected = Path('tests/MultiTypeSections.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_error_reporting(self):
         src = Path('tests/BadSyntax.pas').read_text()
         with self.assertRaises(SyntaxError) as cm:


### PR DESCRIPTION
## Summary
- allow repeating `type` sections in a file
- add tests for multiple `type` sections
- add placeholder example `teste.pas` for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852f976cafc8331a5489d1ecc69fa3c