### PR TITLE
Handle empty except blocks

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -133,7 +133,7 @@ loop_stmt:   LOOP stmt                                       -> loop_stmt
 while_stmt:  "while"i expr "do"i stmt                    -> while_stmt
 
 try_stmt:    "try" stmt* except_clause? finally_clause? "end" ";"? -> try_stmt
-except_clause: "except" (on_handler | stmt)+
+except_clause: "except" (on_handler | stmt)*
 finally_clause: "finally" stmt+
 on_handler: ON CNAME ":" type_name DO stmt -> on_handler
 

--- a/teste.pas
+++ b/teste.pas
@@ -1,0 +1,22 @@
+namespace Demo;
+
+interface
+
+type
+  Example = public class
+  public
+    procedure DoStuff(value: Integer);
+    function Multiply(a: Integer; b: Integer): Integer;
+  end;
+
+implementation
+
+procedure Example.DoStuff(value: Integer);
+begin
+  System.Console.WriteLine('Hi');
+end;
+
+function Example.Multiply(a: Integer; b: Integer): Integer;
+begin
+  result := a * b;
+end;

--- a/tests/TryExceptEmpty.cs
+++ b/tests/TryExceptEmpty.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace Demo {
+    public partial class TryExceptEmptyExample {
+        public static void DoNothing() {
+            try
+            {
+                Console.WriteLine("A");
+            }
+            catch (Exception)
+            {}
+        }
+    }
+}

--- a/tests/TryExceptEmpty.pas
+++ b/tests/TryExceptEmpty.pas
@@ -1,0 +1,23 @@
+namespace Demo;
+
+interface
+
+uses System;
+
+type
+  TryExceptEmptyExample = public class
+  public
+    class method DoNothing();
+  end;
+
+implementation
+
+class method TryExceptEmptyExample.DoNothing();
+begin
+  try
+    Console.WriteLine('A');
+  except
+  end;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -290,6 +290,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_try_except_empty(self):
+        src = Path('tests/TryExceptEmpty.pas').read_text()
+        expected = Path('tests/TryExceptEmpty.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_with_stmt(self):
         src = Path('tests/WithStmt.pas').read_text()
         expected = Path('tests/WithStmt.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -717,7 +717,7 @@ class ToCSharp(Transformer):
         body_cs = "\n".join(indent(s,0) for s in body_stmts if isinstance(s,str) and s.strip())
         res = f"try\n{{\n{indent(body_cs)}\n}}"
 
-        if except_clause:
+        if except_clause is not None:
             generic_body = []
             for handler in except_clause:
                 if isinstance(handler, tuple) and handler[0] == 'on_handler':
@@ -726,9 +726,12 @@ class ToCSharp(Transformer):
                     res += f"\ncatch ({map_type_ext(str(typ))} {name})\n{catch_body}"
                 else:
                     generic_body.append(handler)
-            if generic_body:
+            if generic_body or not except_clause:
                 exc_cs = "\n".join(indent(s,0) for s in generic_body if isinstance(s,str) and s.strip())
-                res += f"\ncatch (Exception)\n{{\n{indent(exc_cs)}\n}}"
+                if exc_cs:
+                    res += f"\ncatch (Exception)\n{{\n{indent(exc_cs)}\n}}"
+                else:
+                    res += "\ncatch (Exception)\n{}"
 
         if finally_clause:
             fin_cs = "\n".join(indent(s,0) for s in finally_clause if isinstance(s,str) and s.strip())


### PR DESCRIPTION
## Summary
- allow `except` without statements in grammar
- emit empty catch blocks for `try except end`
- add tests for empty except case
- add `teste.pas` fixture for existing tests

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_try_except_empty -q`
- `pytest -q` *(fails: KeyboardInterrupt after some tests)*

------
https://chatgpt.com/codex/tasks/task_e_6852f2b1c3d88331bea850a165c86e0d