### PR TITLE
Add support for out/var call args

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -209,7 +209,10 @@ call_expr:   var_ref "(" arg_list? ")" call_postfix* -> call
            | "inherited"i name_term ("(" arg_list? ")")? call_postfix* -> inherited_call_expr
            | typeof_expr call_postfix+                     -> call
 arg_list:    arg ("," arg)*
-arg:         CNAME ":=" expr                         -> named_arg
+arg:         OUT expr                                -> out_arg
+           | VAR expr                                -> var_arg
+           | CONST expr                              -> const_arg
+           | CNAME ":=" expr                         -> named_arg
            | expr
 
 new_stmt:    new_expr ";"?

--- a/tests/IfOr.cs
+++ b/tests/IfOr.cs
@@ -1,0 +1,11 @@
+namespace Demo {
+    public partial class Foo {
+        // TODO: field ehVazio: bool -> declare a field
+        public bool ehVazio;
+        // TODO: field indUltimaPos: int -> declare a field
+        public int indUltimaPos;
+        public bool Check(int frowInd) {
+            if (self.ehVazio || frowInd > self.indUltimaPos || frowInd == -1) return true; else return false;
+        }
+    }
+}

--- a/tests/IfOr.pas
+++ b/tests/IfOr.pas
@@ -1,0 +1,24 @@
+namespace Demo;
+
+type
+  Foo = class
+  private
+    ehVazio: Boolean;
+    indUltimaPos: Integer;
+  public
+    method Check(frowInd: Integer): Boolean;
+  end;
+
+implementation
+
+method Foo.Check(frowInd: Integer): Boolean;
+begin
+  if ( self.ehVazio ) or
+     ( frowInd > self.indUltimaPos) or
+     ( frowInd = -1 )   then
+    result := true
+  else
+    result := false;
+end;
+
+end.

--- a/tests/OutArg.cs
+++ b/tests/OutArg.cs
@@ -1,0 +1,17 @@
+namespace Demo {
+    public partial class SguUtils {
+        public static DateTime UltimoDiaMes(int mes, int ano) {
+            TDateTime d;
+            if (mes == 2) {
+                if (!TryEncodeDate(ano, mes, 29, out d)) TryEncodeDate(ano, mes, 28, out d);
+                return d;
+            } else if (mes == 1 || mes == 3 || mes == 5 || mes == 7 || mes == 8 || mes == 10 || mes == 12) {
+                TryEncodeDate(ano, mes, 31, out d);
+                return d;
+            } else {
+                TryEncodeDate(ano, mes, 30, out d);
+                return d;
+            }
+        }
+    }
+}

--- a/tests/OutArg.pas
+++ b/tests/OutArg.pas
@@ -1,0 +1,37 @@
+namespace Demo;
+
+interface
+
+type
+  SguUtils = public class
+  public
+    class function UltimoDiaMes(mes, ano: Integer): DateTime;
+  end;
+
+implementation
+
+class function SguUtils.UltimoDiaMes(mes, ano: Integer): DateTime;
+var
+  d: TDateTime;
+begin
+  if mes = 2 then
+  begin
+    if not TryEncodeDate(ano, mes, 29, out d) then
+      TryEncodeDate(ano, mes, 28, out d);
+    result := d;
+  end
+  else
+  if (mes = 1) or (mes = 3) or (mes = 5) or (mes = 7) or (mes = 8)
+    or (mes = 10) or (mes = 12) then
+  begin
+    TryEncodeDate(ano, mes, 31, out d);
+    result := d;
+  end
+  else
+  begin
+    TryEncodeDate(ano, mes, 30, out d);
+    result := d;
+  end;
+end;
+
+end.

--- a/tests/VarCallArg.cs
+++ b/tests/VarCallArg.cs
@@ -1,0 +1,9 @@
+namespace Demo {
+    public partial class ExceptionDemo {
+        // TODO: field _unhandledExceptionCount: int -> declare a field
+        public static int _unhandledExceptionCount;
+        public static void Check() {
+            if (Interlocked.Exchange(ref _unhandledExceptionCount, 1) != 0) return;
+        }
+    }
+}

--- a/tests/VarCallArg.pas
+++ b/tests/VarCallArg.pas
@@ -1,0 +1,19 @@
+namespace Demo;
+
+type
+  ExceptionDemo = class
+  private
+    class var _unhandledExceptionCount: Integer;
+  public
+    class procedure Check;
+  end;
+
+implementation
+
+class procedure ExceptionDemo.Check;
+begin
+  if (Interlocked.Exchange(var _unhandledExceptionCount, 1) <> 0) then
+    exit;
+end;
+
+end.

--- a/tests/test_user_parse_errors.py
+++ b/tests/test_user_parse_errors.py
@@ -32,6 +32,12 @@ class NewFeatureTests(unittest.TestCase):
     def test_out_arg(self):
         self.check_pair('OutArg')
 
+    def test_var_call_arg(self):
+        self.check_pair('VarCallArg', allow_todos=True)
+
+    def test_if_or(self):
+        self.check_pair('IfOr', allow_todos=True)
+
     def test_teste_pas_parses(self):
         """Parsing should succeed for the large external example."""
         src = Path('teste.pas').read_text()

--- a/tests/test_user_parse_errors.py
+++ b/tests/test_user_parse_errors.py
@@ -29,8 +29,12 @@ class NewFeatureTests(unittest.TestCase):
     def test_op_assign(self):
         self.check_pair('OpAssign')
 
+    def test_out_arg(self):
+        self.check_pair('OutArg')
+
     def test_teste_pas_parses(self):
         """Parsing should succeed for the large external example."""
         src = Path('teste.pas').read_text()
         result, todos = transpile(src)
         self.assertTrue(result.strip())
+

--- a/transformer.py
+++ b/transformer.py
@@ -374,6 +374,15 @@ class ToCSharp(Transformer):
     def arg(self, value):
         return value
 
+    def out_arg(self, _tok, value):
+        return f"out {value}"
+
+    def var_arg(self, _tok, value):
+        return f"ref {value}"
+
+    def const_arg(self, _tok, value):
+        return value
+
     def named_arg(self, name, expr):
         return expr
 


### PR DESCRIPTION
## Summary
- support `out` and `var` call arguments in the grammar
- emit `out` and `ref` prefixes when translating call arguments
- add test case covering out arguments in procedure calls

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530d4a39988331997227582b6a2b03