### PR TITLE
Add out/var argument parsing

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -210,6 +210,7 @@ call_expr:   var_ref "(" arg_list? ")" call_postfix* -> call
            | typeof_expr call_postfix+                     -> call
 arg_list:    arg ("," arg)*
 arg:         CNAME ":=" expr                         -> named_arg
+           | (OUT | VAR) expr                        -> out_arg
            | expr
 
 new_stmt:    new_expr ";"?

--- a/tests/OutArg.cs
+++ b/tests/OutArg.cs
@@ -1,0 +1,12 @@
+namespace Demo {
+    public partial class OutArg {
+        public void DoStuff() {
+            int d;
+            bool ok;
+            int frowInd;
+            if (!TryEncodeDate(1, 1, 29, out d)) TryEncodeDate(1, 1, 28, out d);
+            if (self.ehVazio || frowInd > self.indUltimaPos || frowInd == -1) ok = true; else ok = false;
+            UseValue(ref d);
+        }
+    }
+}

--- a/tests/OutArg.pas
+++ b/tests/OutArg.pas
@@ -1,0 +1,28 @@
+namespace Demo;
+
+type
+  OutArg = public class
+  public
+    method DoStuff;
+  end;
+
+implementation
+
+method OutArg.DoStuff;
+var
+  d: Integer;
+  ok: Boolean;
+  frowInd: Integer;
+begin
+  if not TryEncodeDate(1, 1, 29, out d) then
+    TryEncodeDate(1, 1, 28, out d);
+  if ( self.ehVazio ) or
+     ( frowInd > self.indUltimaPos ) or
+     ( frowInd = -1 ) then
+    ok := true
+  else
+    ok := false;
+  UseValue(var d);
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -478,6 +478,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_out_arg(self):
+        src = Path('tests/OutArg.pas').read_text()
+        expected = Path('tests/OutArg.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_error_reporting(self):
         src = Path('tests/BadSyntax.pas').read_text()
         with self.assertRaises(SyntaxError) as cm:

--- a/transformer.py
+++ b/transformer.py
@@ -377,6 +377,10 @@ class ToCSharp(Transformer):
     def named_arg(self, name, expr):
         return expr
 
+    def out_arg(self, tok, expr):
+        prefix = 'out' if str(tok).lower() == 'out' else 'ref'
+        return f"{prefix} {expr}"
+
     def method_decl(self, *parts):
         for p in parts:
             if isinstance(p, str) and p.strip().startswith("public"):


### PR DESCRIPTION
## Summary
- support `out` and `var` modifiers in call arguments
- add matching transformer logic
- cover with tests

## Testing
- `pytest -q tests/test_transpile.py::TranspileTests::test_out_arg`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530d4a39988331997227582b6a2b03