### PR TITLE
Fix generics in chained method calls

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -199,14 +199,14 @@ generic_call_base: dotted_name GENERIC_ARGS
 
 ?call_postfix: prop_call | index_postfix
 call_args: "(" arg_list? ")"                         -> call_args
-prop_call: "." name_term call_args?                  -> prop_call
+prop_call: "." name_term GENERIC_ARGS? call_args?     -> prop_call
 index_postfix: ARRAY_RANGE                           -> index_postfix
 
 call_expr:   var_ref "(" arg_list? ")" call_postfix* -> call
            | generic_call_base ("(" arg_list? ")")? call_postfix* -> call
-           | new_expr "." name_term ("(" arg_list? ")")? call_postfix* -> call
-           | "(" expr ")" "." name_term ("(" arg_list? ")")? call_postfix* -> call
-           | "inherited"i name_term ("(" arg_list? ")")? call_postfix* -> inherited_call_expr
+           | new_expr "." name_term GENERIC_ARGS? call_args? call_postfix* -> call
+           | "(" expr ")" "." name_term GENERIC_ARGS? call_args? call_postfix* -> call
+           | "inherited"i name_term GENERIC_ARGS? call_args? call_postfix* -> inherited_call_expr
            | typeof_expr call_postfix+                     -> call
 arg_list:    arg ("," arg)*
 arg:         CNAME ":=" expr                         -> named_arg

--- a/tests/Generics.cs
+++ b/tests/Generics.cs
@@ -1,4 +1,6 @@
 using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+using System.Collections;
 
 namespace Demo {
     public partial class MyList : List<string> {
@@ -11,6 +13,10 @@ namespace Demo {
             List<int> v;
             v = new List<int>();
             l.AddRange(v);
+        }
+        public void Parse(JObject ret) {
+            Hashtable aux;
+            aux = (ret as JObject).ToObject<Hashtable>();
         }
     }
     

--- a/tests/Generics.pas
+++ b/tests/Generics.pas
@@ -2,7 +2,7 @@ namespace Demo;
 
 interface
 
-uses System.Collections.Generic;
+uses System.Collections.Generic, Newtonsoft.Json.Linq, System.Collections;
 
 type
   MyList = public class(List<String>)
@@ -13,6 +13,7 @@ type
   GenExample = public class
   public
     method UseList(l: List<String>);
+    method Parse(ret: JObject);
   end;
 
   GenericStatic = public class
@@ -37,6 +38,13 @@ var
 begin
   v := new List<Integer>;
   l.AddRange(v);
+end;
+
+method GenExample.Parse(ret: JObject);
+var
+  aux: Hashtable;
+begin
+  aux := (ret as JObject).ToObject<Hashtable>();
 end;
 
 class method GenericStatic.Use();


### PR DESCRIPTION
## Summary
- support generic arguments after chained method calls
- adjust call handling for generics and empty calls
- test generic method call

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68530ee634c48331a96ea5e743d52c5d