### PR TITLE
Fix parsing edge cases

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -139,7 +139,12 @@ on_handler: ON CNAME ":" type_name DO stmt -> on_handler
 
 case_stmt:   "case" expr "of" case_branch+ ("else" stmt+)? "end" ";"? -> case_stmt
 case_branch: case_label ("," case_label)* ":" stmt ";"?
-case_label: NUMBER | SQ_STRING | STRING | CNAME | NIL
+case_label: NUMBER DOTDOT NUMBER        -> label_range
+          | NUMBER
+          | SQ_STRING
+          | STRING
+          | CNAME
+          | NIL
 
 call_stmt:   var_ref ("(" arg_list? ")")? call_postfix* ";"?   -> call_stmt
            | generic_call_base ("(" arg_list? ")")? call_postfix* ";"? -> call_stmt
@@ -217,6 +222,7 @@ arg:         OUT expr                                -> out_arg
 
 new_stmt:    new_expr ";"?
 var_ref:     name_base (ARRAY_RANGE | "." name_term)* -> var
+           | "(" expr ")" ARRAY_RANGE -> paren_index
 
 var_section: "var"i (var_decl | var_decl_infer)+
 var_decl:    name_list ":" type_spec (":=" expr)? ";"       -> var_decl
@@ -292,9 +298,10 @@ DOTDOT:      ".."
 CHAR_CODE:   "#" NUMBER ("#" NUMBER)*
 
 %import common.CNAME -> BASE_CNAME
-%import common.NUMBER
-%import common.ESCAPED_STRING -> STRING
 %import common.WS
+
+NUMBER: /[0-9][_0-9]*/
+STRING: /"[^"\n]*"/
 
 CNAME: /&?[A-Za-z_][A-Za-z_0-9]*\??/
 COMMENT_BRACE: /\{[^}]*\}/

--- a/tests/BugFixes.cs
+++ b/tests/BugFixes.cs
@@ -1,0 +1,26 @@
+namespace Demo {
+    public partial class BugFixes {
+        public void CastIndex(Hashtable ret, Hashtable aux, object k) {
+            (ret as Hashtable)[k] = ToHashtable((aux as Hashtable)[k]);
+        }
+        public void PathJoin(string nome_arquivo) {
+            string path;
+            path = U.Business.TSguUtils.PathRaizAbsoluto + "\\arquivos\\" + nome_arquivo;
+        }
+        public void CaseRange(int x) {
+            switch (x)
+            {
+                case 1:
+                case 2:
+                case 3: System.Console.WriteLine("low"); break;
+                case 4: System.Console.WriteLine("four"); break;
+            }
+        }
+        public void Underscore(object ds) {
+            if (ds.Tables[0].Rows.Count > 10000) System.Console.WriteLine("big");
+        }
+        public void Backslash(string src) {
+            src = src.Replace("\\", "\\\\");
+        }
+    }
+}

--- a/tests/BugFixes.pas
+++ b/tests/BugFixes.pas
@@ -1,0 +1,45 @@
+namespace Demo;
+
+type
+  BugFixes = public class
+  public
+    method CastIndex(ret, aux: Hashtable; k: Object);
+    method PathJoin(nome_arquivo: String);
+    method CaseRange(x: Integer);
+    method Underscore(ds: Object);
+    method Backslash(src: String);
+  end;
+
+implementation
+
+method BugFixes.CastIndex(ret, aux: Hashtable; k: Object);
+begin
+  (ret as Hashtable)[k] := ToHashtable((aux as Hashtable)[k]);
+end;
+
+method BugFixes.PathJoin(nome_arquivo: String);
+var path: String;
+begin
+  path := U.Business.TSguUtils.PathRaizAbsoluto + "\arquivos\" + nome_arquivo;
+end;
+
+method BugFixes.CaseRange(x: Integer);
+begin
+  case x of
+    1..3: System.Console.WriteLine('low');
+    4:    System.Console.WriteLine('four');
+  end;
+end;
+
+method BugFixes.Underscore(ds: Object);
+begin
+  if ds.Tables[0].Rows.Count > 10_000 then
+    System.Console.WriteLine('big');
+end;
+
+method BugFixes.Backslash(src: String);
+begin
+  src := src.Replace("\", "\\");
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -478,6 +478,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_bug_fixes(self):
+        src = Path('tests/BugFixes.pas').read_text()
+        expected = Path('tests/BugFixes.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_error_reporting(self):
         src = Path('tests/BadSyntax.pas').read_text()
         with self.assertRaises(SyntaxError) as cm:


### PR DESCRIPTION
## Summary
- allow numeric literals with underscores
- parse `(expr)[index]` constructs
- support case labels with ranges
- handle double-quoted strings with backslashes
- add tests covering the new cases

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_bug_fixes -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853164004c48331a513455534d78313