### PR TITLE
Allow final `End;`

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -1,6 +1,6 @@
 # ────────────────────────── Grammar ──────────────────────────
 GRAMMAR = r"""
-?start:   namespace interface_section? class_section+ ("implementation" uses_clause? class_impl*)? ("end" ".")?
+?start:   namespace interface_section? class_section+ ("implementation" uses_clause? class_impl*)? ("end"i ("." | ";"))?
 
 interface_section: "interface" uses_clause? pre_class_decl*
 uses_clause:   "uses" dotted_name ("," dotted_name)* ";"       -> uses
@@ -84,7 +84,7 @@ class_impl:  class_modifier? method_kind method_impl
 method_impl: impl_head ";" var_section? block               -> m_impl
 impl_head:   method_name param_block? return_block?
 
-block:       "begin" stmt* "end" ";"?
+block:       "begin" stmt* "end"i ";"?
 
 ?stmt:       assign_stmt
            | op_assign_stmt
@@ -132,12 +132,12 @@ for_stmt:    "for"i CNAME (":" type_spec)? ":=" expr (TO | DOWNTO) expr (STEP ex
 loop_stmt:   LOOP stmt                                       -> loop_stmt
 while_stmt:  "while"i expr "do"i stmt                    -> while_stmt
 
-try_stmt:    "try" stmt* except_clause? finally_clause? "end" ";"? -> try_stmt
+try_stmt:    "try" stmt* except_clause? finally_clause? "end"i ";"? -> try_stmt
 except_clause: "except" (on_handler | stmt)*
 finally_clause: "finally" stmt+
 on_handler: ON CNAME ":" type_name DO stmt -> on_handler
 
-case_stmt:   "case" expr "of" case_branch+ ("else" stmt+)? "end" ";"? -> case_stmt
+case_stmt:   "case" expr "of" case_branch+ ("else" stmt+)? "end"i ";"? -> case_stmt
 case_branch: case_label ("," case_label)* ":" stmt ";"?
 case_label: NUMBER | SQ_STRING | STRING | CNAME | NIL
 

--- a/tests/EndSemicolon.cs
+++ b/tests/EndSemicolon.cs
@@ -1,0 +1,5 @@
+namespace Demo {
+    public partial class Foo {
+    
+    }
+}

--- a/tests/EndSemicolon.pas
+++ b/tests/EndSemicolon.pas
@@ -1,0 +1,7 @@
+namespace Demo;
+
+type
+  Foo = public class
+  end;
+
+End;

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -484,5 +484,12 @@ class TranspileTests(unittest.TestCase):
             transpile(src)
         self.assertIn('Parse error', str(cm.exception))
 
+    def test_file_end_semicolon(self):
+        src = Path('tests/EndSemicolon.pas').read_text()
+        expected = Path('tests/EndSemicolon.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- support Pascal-case `End;` at the end of Pascal files
- handle `End;` within blocks, try statements, and case statements

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_loops -q`
- `pytest tests/test_transpile.py::TranspileTests::test_misc_ops -q`
- `pytest tests/test_user_parse_errors.py::NewFeatureTests::test_out_arg -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853174e3300833186102182bd3ecf0e