### PR TITLE
Support Pascal 'div' operator

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -232,7 +232,7 @@ LT:           "<"
 GT:           ">"
 GENERIC_ARGS: /<(?![=>])(?:(?:[^<>]|<[^<>]*>)+)>/
 OP_SUM:       "+" | "-" | "or"
-OP_MUL:       "*" | "/" | "and" | "mod"i
+OP_MUL:       "*" | "/" | "and" | "mod"i | "div"i
 OP_REL:       "=" | "<>" | "<=" | ">="
 ADD_ASSIGN.2:  "+="
 SUB_ASSIGN.2:  "-="

--- a/tests/DivExpr.cs
+++ b/tests/DivExpr.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class Utils {
+        public static void Check(int x, int y) {
+            if (x / y != 0) x = x / y;
+        }
+    }
+}

--- a/tests/DivExpr.pas
+++ b/tests/DivExpr.pas
@@ -1,0 +1,17 @@
+namespace Demo;
+
+type
+  Utils = public class
+  public
+    class method Check(x: Integer; y: Integer);
+  end;
+
+implementation
+
+class method Utils.Check(x: Integer; y: Integer);
+begin
+  if (x div y) <> 0 then
+    x := x div y;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -234,6 +234,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_div_expr(self):
+        src = Path('tests/DivExpr.pas').read_text()
+        expected = Path('tests/DivExpr.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_less_than_call(self):
         src = Path('tests/LessThanCall.pas').read_text()
         expected = Path('tests/LessThanCall.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -839,6 +839,7 @@ class ToCSharp(Transformer):
             "<>": "!=",
             "=": "==",
             "mod": "%",
+            "div": "/",
         }
         return f"{left} {op_map.get(op, op)} {right}"
 

--- a/utils.py
+++ b/utils.py
@@ -66,6 +66,8 @@ def fix_keyword(tok):
         tok.type = "NOT"
     elif v == "mod":
         tok.type = "OP_MUL"
+    elif v == "div":
+        tok.type = "OP_MUL"
     elif v == "while":
         tok.type = "WHILE"
     elif v == "do":


### PR DESCRIPTION
## Summary
- add `div` token to `OP_MUL` so integer division parses
- recognize `div` keyword in lexer
- translate `div` to `/` in binop mapping
- test Pascal integer division support

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_div_expr -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a90909f8c83318c8c83a4223e9b96