### PR TITLE
Allow semicolon after begin

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -84,7 +84,7 @@ class_impl:  class_modifier? method_kind method_impl
 method_impl: impl_head ";" var_section? block               -> m_impl
 impl_head:   method_name param_block? return_block?
 
-block:       "begin" stmt* "end"i ";"?
+block:       "begin" ";"? stmt* "end"i ";"?
 
 ?stmt:       assign_stmt
            | op_assign_stmt

--- a/tests/BeginSemicolon.cs
+++ b/tests/BeginSemicolon.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class BeginSemi {
+        public static void Foo() {
+            System.Console.WriteLine("Hello");
+        }
+    }
+}

--- a/tests/BeginSemicolon.pas
+++ b/tests/BeginSemicolon.pas
@@ -1,0 +1,16 @@
+namespace Demo;
+
+type
+  BeginSemi = class
+  public
+    class method Foo;
+  end;
+
+implementation
+
+class method BeginSemi.Foo;
+begin;
+  System.Console.WriteLine('Hello');
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -505,5 +505,12 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_begin_semicolon(self):
+        src = Path('tests/BeginSemicolon.pas').read_text()
+        expected = Path('tests/BeginSemicolon.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- extend `block` grammar rule to accept an optional semicolon immediately after `begin`
- add tests covering Pascal code that starts a block with `begin;`

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_begin_semicolon -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a90c94db8833181413bd148b6a17d