### PR TITLE
Fix multi-line paren comment parsing

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -306,7 +306,7 @@ STRING: /"[^"\n]*"/
 CNAME: /&?[A-Za-z_][A-Za-z_0-9]*\??/
 COMMENT_BRACE: /\{[^}]*\}/
 LINE_COMMENT: /\/\/[^\n]*/
-COMMENT_PAREN: /\(\*[^*]*\*\)/
+COMMENT_PAREN: /\(\*[\s\S]*?\*\)/
 %ignore WS
 %ignore COMMENT_BRACE
 %ignore LINE_COMMENT

--- a/tests/ParenComment.cs
+++ b/tests/ParenComment.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class Foo {
+        public int Value() {
+            return 123;
+        }
+    }
+}

--- a/tests/ParenComment.pas
+++ b/tests/ParenComment.pas
@@ -1,0 +1,18 @@
+namespace Demo;
+
+type
+  Foo = class
+  public
+    method Value: Integer;
+  end;
+
+implementation
+
+method Foo.Value: Integer;
+begin
+  (* comment with *** inside
+     multiple lines *)
+  result := 123;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -45,6 +45,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_paren_comment(self):
+        src = Path('tests/ParenComment.pas').read_text()
+        expected = Path('tests/ParenComment.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_single_stmt(self):
         src = Path('tests/SingleStmt.pas').read_text()
         expected = Path('tests/SingleStmt.cs').read_text().strip()


### PR DESCRIPTION
## Summary
- support `(* ... *)` comments spanning multiple lines
- add regression test for nested `*` characters inside parenthesis comments

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_paren_comment -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685aa0977e008331bd180dfce07d3ecc