### PR TITLE
Support local constants in method implementations

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -81,7 +81,8 @@ pre_class_decl: const_block
               | method_decl_rule
 
 class_impl:  class_modifier? method_kind method_impl
-method_impl: impl_head ";" var_section? block               -> m_impl
+method_impl: impl_head ";" method_decls? block               -> m_impl
+method_decls: (var_section | const_block)+
 impl_head:   method_name param_block? return_block?
 
 block:       "begin" ";"? stmt* "end"i ";"?

--- a/tests/LocalConst.cs
+++ b/tests/LocalConst.cs
@@ -1,0 +1,12 @@
+namespace Demo {
+    public partial class LocalConstEx {
+        public static void Test() {
+            int i, j;
+            var str = "mysqrt";
+            i = 1;
+            j = 2;
+            return str;
+        }
+    }
+}
+

--- a/tests/LocalConst.pas
+++ b/tests/LocalConst.pas
@@ -1,0 +1,23 @@
+namespace Demo;
+
+type
+  LocalConstEx = public class
+  public
+    class method Test;
+  end;
+
+implementation
+
+class method LocalConstEx.Test;
+var
+  i, j: Integer;
+const
+  str = 'mysqrt';
+begin
+  i := 1;
+  j := 2;
+  result := str;
+end;
+
+end.
+

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -533,5 +533,12 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_local_const(self):
+        src = Path('tests/LocalConst.pas').read_text()
+        expected = Path('tests/LocalConst.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
 if __name__ == '__main__':
     unittest.main()

--- a/transformer.py
+++ b/transformer.py
@@ -526,6 +526,13 @@ class ToCSharp(Transformer):
         expr = parts[0] if parts else None
         t = map_type_ext(str(typ)) if typ else 'var'
         safe_name = self._safe_name(name)
+        if self.curr_method:
+            if typ:
+                line = f"const {t} {safe_name} = {expr};"
+            else:
+                line = f"var {safe_name} = {expr};"
+            self.curr_locals.add(str(safe_name))
+            return line
         info = f"// TODO: const {safe_name} -> define a constant"
         impl = f"public const {t} {safe_name} = {expr};"
         self.todo.append(info)
@@ -534,6 +541,10 @@ class ToCSharp(Transformer):
     def const_block(self, *parts):
         decls = parts[1:] if parts and parts[0] == "" else parts
         return "\n".join(decls)
+
+    def method_decls(self, *sections):
+        parts = [s for s in sections if s]
+        return "\n".join(parts)
 
     # ── implementation part ─────────────────────────────────
     def m_impl(self, head, *parts):


### PR DESCRIPTION
## Summary
- extend grammar to allow const sections in method implementations
- generate local const declarations during transpilation
- add LocalConst test case

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_local_const -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd797e9cc833188b8a7177c3f1377