### PR TITLE
Add support for Pascal 'is not' type check

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -164,6 +164,7 @@ inherited_stmt: "inherited"i (name_term ("(" arg_list? ")" call_postfix*)?)? ";"
            | expr (OP_REL|LT|GT) expr                -> binop
            | expr IN set_lit                         -> in_expr
            | expr NOT IN set_lit                     -> not_in_expr
+           | expr IS NOT type_spec                   -> is_not_inst
            | expr IS type_spec                       -> is_inst
            | expr AS type_spec                       -> as_cast
            | "(" expr ")"

--- a/tests/IsNotType.cs
+++ b/tests/IsNotType.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class IsNotExample {
+        public void Check(object o) {
+            if (o is not string) Console.WriteLine("not string");
+        }
+    }
+}

--- a/tests/IsNotType.pas
+++ b/tests/IsNotType.pas
@@ -1,0 +1,17 @@
+namespace Demo;
+
+type
+  IsNotExample = class
+  public
+    method Check(o: Object);
+  end;
+
+implementation
+
+method IsNotExample.Check(o: Object);
+begin
+  if o is not String then
+    Console.WriteLine('not string');
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -422,6 +422,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_is_not_type(self):
+        src = Path('tests/IsNotType.pas').read_text()
+        expected = Path('tests/IsNotType.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_reserved_prop(self):
         src = Path('tests/ReservedProp.pas').read_text()
         expected = Path('tests/ReservedProp.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -1039,6 +1039,9 @@ class ToCSharp(Transformer):
     def typeof_expr(self, _tok, typ, _rp=None):
         return f"typeof({map_type_ext(str(typ))})"
 
+    def is_not_inst(self, expr, _is_tok, _not_tok, typ):
+        return f"{expr} is not {map_type_ext(str(typ))}"
+
     def is_inst(self, expr, _tok, typ):
         return f"{expr} is {map_type_ext(str(typ))}"
 


### PR DESCRIPTION
## Summary
- extend grammar to parse `is not` expressions
- output `is not` with new transformer rule
- test `is not` check

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_is_not_type -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bd773b8f08331bf0feb9e3291c00f