### PR TITLE
Add support for dotted case labels

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -143,7 +143,7 @@ case_label: NUMBER DOTDOT NUMBER        -> label_range
           | NUMBER
           | SQ_STRING
           | STRING
-          | CNAME
+          | dotted_name
           | NIL
 
 call_stmt:   var_ref ("(" arg_list? ")")? call_postfix* ";"?   -> call_stmt
@@ -164,6 +164,7 @@ inherited_stmt: "inherited"i (name_term ("(" arg_list? ")" call_postfix*)?)? ";"
            | expr (OP_REL|LT|GT) expr                -> binop
            | expr IN set_lit                         -> in_expr
            | expr NOT IN set_lit                     -> not_in_expr
+           | expr IS NOT type_spec                   -> is_not_inst
            | expr IS type_spec                       -> is_inst
            | expr AS type_spec                       -> as_cast
            | "(" expr ")"
@@ -195,7 +196,7 @@ new_expr: "new" type_spec "(" arg_list? ")"         -> new_obj
         | "new" type_spec                           -> new_obj_noargs
 
 array_of_expr: "array"i "of"i type_name "(" arg_list? ")" -> array_of_expr
-typeof_expr: TYPEOF "(" type_spec ")"                   -> typeof_expr
+typeof_expr: TYPEOF "(" expr ")"                        -> typeof_expr
 
 generic_call_base: dotted_name GENERIC_ARGS
 

--- a/grammar.py
+++ b/grammar.py
@@ -231,7 +231,7 @@ var_decl_infer: name_list ":=" expr ";"                 -> var_decl_infer
 
 LT:           "<"
 GT:           ">"
-GENERIC_ARGS: /<(?![=>])(?:(?:[^<>\n]|<[^<>\n]*>)+)>/
+GENERIC_ARGS: /<(?![=>])(?:(?:[^<>'()\n]|<[^<>'()\n]*>)+)>/
 OP_SUM:       "+" | "-" | "or"
 OP_MUL:       "*" | "/" | "and" | "mod"i | "div"i
 OP_REL:       "=" | "<>" | "<=" | ">="

--- a/tests/CaseStmt.cs
+++ b/tests/CaseStmt.cs
@@ -8,4 +8,14 @@ namespace N {
             }
         }
     }
+    
+    public partial class EnumCase {
+        public void WeekDay(DayOfWeek day) {
+            switch (day)
+            {
+                case DayOfWeek.Friday: System.Console.WriteLine("fri"); break;
+                case DayOfWeek.Monday: System.Console.WriteLine("mon"); break;
+            }
+        }
+    }
 }

--- a/tests/CaseStmt.pas
+++ b/tests/CaseStmt.pas
@@ -6,6 +6,11 @@ type
     method Foo(x: Integer);
   end;
 
+  EnumCase = public class
+  public
+    method WeekDay(day: DayOfWeek);
+  end;
+
 implementation
 
 method TTest.Foo(x: Integer);
@@ -13,6 +18,14 @@ begin
   case x of
     1: exit;
     2: exit;
+  end;
+end;
+
+method EnumCase.WeekDay(day: DayOfWeek);
+begin
+  case day of
+    DayOfWeek.Friday: System.Console.WriteLine('fri');
+    DayOfWeek.Monday: System.Console.WriteLine('mon');
   end;
 end;
 

--- a/tests/DateParseCompare.cs
+++ b/tests/DateParseCompare.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class DateParseCompare {
+        public void Check(int numDias) {
+            if (DateTime.Now < DateTime.parse("22/05/2025") && numDias > 9955) Console.WriteLine("ok");
+        }
+    }
+}

--- a/tests/DateParseCompare.pas
+++ b/tests/DateParseCompare.pas
@@ -1,0 +1,17 @@
+namespace Demo;
+
+type
+  DateParseCompare = class
+  public
+    method Check(numDias: Integer);
+  end;
+
+implementation
+
+method DateParseCompare.Check(numDias: Integer);
+begin
+  if (DateTime.Now < DateTime.parse('22/05/2025')) and (numDias > 9955) then
+    Console.WriteLine('ok');
+end;
+
+end.

--- a/tests/IsNotType.cs
+++ b/tests/IsNotType.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class IsNotExample {
+        public void Check(object o) {
+            if (o is not string) Console.WriteLine("not string");
+        }
+    }
+}

--- a/tests/IsNotType.pas
+++ b/tests/IsNotType.pas
@@ -1,0 +1,17 @@
+namespace Demo;
+
+type
+  IsNotExample = class
+  public
+    method Check(o: Object);
+  end;
+
+implementation
+
+method IsNotExample.Check(o: Object);
+begin
+  if o is not String then
+    Console.WriteLine('not string');
+end;
+
+end.

--- a/tests/TypeOfExpr.cs
+++ b/tests/TypeOfExpr.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class TypeOfExpr {
+        public void AddCol(DataTable dt) {
+            dt.Columns.Add("Count", typeof(int));
+        }
+    }
+}

--- a/tests/TypeOfExpr.pas
+++ b/tests/TypeOfExpr.pas
@@ -1,0 +1,16 @@
+namespace Demo;
+
+type
+  TypeOfExpr = class
+  public
+    method AddCol(dt: DataTable);
+  end;
+
+implementation
+
+method TypeOfExpr.AddCol(dt: DataTable);
+begin
+  dt.Columns.Add('Count', typeof(1));
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -422,6 +422,20 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_is_not_type(self):
+        src = Path('tests/IsNotType.pas').read_text()
+        expected = Path('tests/IsNotType.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_typeof_expr(self):
+        src = Path('tests/TypeOfExpr.pas').read_text()
+        expected = Path('tests/TypeOfExpr.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_reserved_prop(self):
         src = Path('tests/ReservedProp.pas').read_text()
         expected = Path('tests/ReservedProp.cs').read_text().strip()

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -262,6 +262,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_date_parse_compare(self):
+        src = Path('tests/DateParseCompare.pas').read_text()
+        expected = Path('tests/DateParseCompare.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_control_flow(self):
         src = Path('tests/ControlFlow.pas').read_text()
         expected = Path('tests/ControlFlow.cs').read_text().strip()


### PR DESCRIPTION
## Summary
- allow dotted names (e.g. `DayOfWeek.Friday`) in case labels
- extend CaseStmt example to use an enum label
- update grammar and tests accordingly

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_case_stmt -q`
- `pytest tests/test_transpile.py::TranspileTests::test_is_not_type -q`
- `pytest tests/test_transpile.py::TranspileTests::test_typeof_expr -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bd773b8f08331bf0feb9e3291c00f