### PR TITLE
Support inline if expressions

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -186,6 +186,7 @@ inherited_stmt: "inherited"i (name_term ("(" arg_list? ")" call_postfix*)?)? ";"
            | array_of_expr
            | new_expr
            | anon_proc_expr
+           | "if" expr "then" expr "else" expr         -> if_expr
            | CHAR_CODE                               -> char_code
            | expr CARET                              -> deref
 

--- a/tests/IfExpr.cs
+++ b/tests/IfExpr.cs
@@ -1,0 +1,9 @@
+namespace Demo {
+    public partial class Ternary {
+        public static int Select(bool flag) {
+            int val;
+            val = flag ? 1 : 0;
+            return val;
+        }
+    }
+}

--- a/tests/IfExpr.pas
+++ b/tests/IfExpr.pas
@@ -1,0 +1,19 @@
+namespace Demo;
+
+type
+  Ternary = class
+  public
+    class method Select(flag: Boolean): Integer;
+  end;
+
+implementation
+
+class method Ternary.Select(flag: Boolean): Integer;
+var
+  val: Integer;
+begin
+  val := if flag then 1 else 0;
+  result := val;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -520,6 +520,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_if_expr(self):
+        src = Path('tests/IfExpr.pas').read_text()
+        expected = Path('tests/IfExpr.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_multi_type_sections(self):
         src = Path('tests/MultiTypeSections.pas').read_text()
         expected = Path('tests/MultiTypeSections.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -1097,6 +1097,9 @@ class ToCSharp(Transformer):
         sig = self.lambda_sig(params)
         return f"{sig} => {block}"
 
+    def if_expr(self, cond, true_val, false_val):
+        return f"{cond} ? {true_val} : {false_val}"
+
     def char_code(self, tok):
         nums = [int(n) for n in tok.value[1:].split('#') if n]
         chars = []


### PR DESCRIPTION
## Summary
- extend grammar for inline `if` expressions
- generate C# ternary in transformer
- add tests for conditional expression

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_if_expr -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bf47a13b0833192f57615bbe43717