### PR TITLE
Support inline if expressions

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -162,8 +162,11 @@ inherited_stmt: "inherited"i (name_term ("(" arg_list? ")" call_postfix*)?)? ";"
            | AT var_ref                              -> addr_of
            | expr OP_SUM   expr                      -> binop
            | expr OP_MUL   expr                      -> binop
+           | expr SHL expr                          -> binop
+           | expr SHR expr                          -> binop
            | expr OP_SUM ELSE expr                   -> short_or
            | expr OP_MUL THEN expr                   -> short_and
+           | "if" expr "then" expr "else" expr       -> if_expr
            | expr (OP_REL|LT|GT) expr                -> binop
            | expr IN set_lit                         -> in_expr
            | expr NOT IN set_lit                     -> not_in_expr
@@ -240,6 +243,8 @@ GENERIC_ARGS: /<(?![=>])(?:(?:[^<>'()\n]|<[^<>'()\n]*>)+)>/
 OP_SUM:       "+" | "-" | "or"
 OP_MUL:       "*" | "/" | "and" | "mod"i | "div"i
 OP_REL:       "=" | "<>" | "<=" | ">="
+SHL:          "shl"i
+SHR:          "shr"i
 ADD_ASSIGN.2:  "+="
 SUB_ASSIGN.2:  "-="
 

--- a/tests/ShiftOps.cs
+++ b/tests/ShiftOps.cs
@@ -1,0 +1,9 @@
+namespace Demo {
+    public partial class Utils {
+        public int Shifts(int maskBits) {
+            var shifted = 1 << maskBits;
+            var maskByte = 255 >> maskBits;
+            return shifted + maskByte;
+        }
+    }
+}

--- a/tests/ShiftOps.pas
+++ b/tests/ShiftOps.pas
@@ -1,0 +1,18 @@
+namespace Demo;
+
+type
+  Utils = class
+  public
+    method Shifts(maskBits: Integer): Integer;
+  end;
+
+implementation
+
+method Utils.Shifts(maskBits: Integer): Integer;
+begin
+  var shifted := 1 shl maskBits;
+  var maskByte := 255 shr maskBits;
+  result := shifted + maskByte;
+end;
+
+end.

--- a/tests/TernaryIf.cs
+++ b/tests/TernaryIf.cs
@@ -1,0 +1,8 @@
+namespace Demo {
+    public partial class Utils {
+        public int Pick(int a, int b) {
+            var res = (a > b) ? a : b;
+            return res;
+        }
+    }
+}

--- a/tests/TernaryIf.pas
+++ b/tests/TernaryIf.pas
@@ -1,0 +1,17 @@
+namespace Demo;
+
+type
+  Utils = class
+  public
+    method Pick(a, b: Integer): Integer;
+  end;
+
+implementation
+
+method Utils.Pick(a, b: Integer): Integer;
+begin
+  var res := if a > b then a else b;
+  result := res;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -578,5 +578,19 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_ternary_if(self):
+        src = Path('tests/TernaryIf.pas').read_text()
+        expected = Path('tests/TernaryIf.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_shift_ops(self):
+        src = Path('tests/ShiftOps.pas').read_text()
+        expected = Path('tests/ShiftOps.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
 if __name__ == '__main__':
     unittest.main()

--- a/transformer.py
+++ b/transformer.py
@@ -853,6 +853,8 @@ class ToCSharp(Transformer):
             "=": "==",
             "mod": "%",
             "div": "/",
+            "shl": "<<",
+            "shr": ">>",
         }
         return f"{left} {op_map.get(op, op)} {right}"
 
@@ -861,6 +863,9 @@ class ToCSharp(Transformer):
 
     def short_and(self, left, _and, _then, right):
         return self.binop(left, "and then", right)
+
+    def if_expr(self, cond, true_expr, false_expr):
+        return f"({cond}) ? {true_expr} : {false_expr}"
 
     def not_expr(self, _tok, expr):
         return f"!{expr}"


### PR DESCRIPTION
## Summary
- add grammar rule for inline `if` expressions
- generate C# ternary code from `if` expressions
- add regression test
- add shift operators `shl` and `shr`

## Testing
- `pytest -q tests/test_transpile.py::TranspileTests::test_ternary_if`
- `pytest -q tests/test_transpile.py::TranspileTests::test_shift_ops`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bf47a13b0833192f57615bbe43717