### PR TITLE
Handle backslashes in Pascal strings

### DIFF
--- a/tests/BugFixes.cs
+++ b/tests/BugFixes.cs
@@ -25,5 +25,8 @@ namespace Demo {
         public void Backslash(string src) {
             src = src.Replace("\\", "\\\\");
         }
+        public void SQPath() {
+            System.Console.WriteLine("C:\\temp\\file.txt");
+        }
     }
 }

--- a/tests/BugFixes.pas
+++ b/tests/BugFixes.pas
@@ -49,4 +49,9 @@ begin
   src := src.Replace("\", "\\");
 end;
 
+method BugFixes.SQPath;
+begin
+  System.Console.WriteLine('C:\temp\file.txt');
+end;
+
 end.

--- a/tests/ExportarDados.cs
+++ b/tests/ExportarDados.cs
@@ -37,14 +37,14 @@ namespace SGUWeb {
             TFuncionario f;
             f = new TFuncionario();
             f.ConsistenciaAdicionaisFolhaLTCAT();
-            f.gerarCSV(TSguUtils.PathRaizAbsoluto + "\\arquivos\\Adicionais.csv");
+            f.gerarCSV(TSguUtils.PathRaizAbsoluto + "\\\\arquivos\\\\Adicionais.csv");
             hlAdicionais.Visible = true;
         }
         public void Button2_Click(object sender, System.EventArgs e) {
             TSetorAlocacao s;
             s = new TSetorAlocacao();
             s.BuscarAlocacoes();
-            s.gerarCSV(TSguUtils.PathRaizAbsoluto + "\\arquivos\\Colaboradores.csv");
+            s.gerarCSV(TSguUtils.PathRaizAbsoluto + "\\\\arquivos\\\\Colaboradores.csv");
             hlColaboradores.Visible = true;
         }
     }

--- a/transformer.py
+++ b/transformer.py
@@ -900,6 +900,7 @@ class ToCSharp(Transformer):
         s = str(s)
         if s.startswith("'"):
             inner = s[1:-1].replace("''", "'")
+            inner = inner.replace('\\', '\\\\')
             inner = inner.replace('"', '\\"')
             return f'"{inner}"'
         else:


### PR DESCRIPTION
## Summary
- escape backslashes in single-quoted strings
- add regression test for single-quoted backslashes
- update expected output for ExportarDados

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_bug_fixes -q`
- `pytest tests/test_transpile.py::TranspileTests::test_exportar_dados -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c461f0b0c8331b7cb8680c7ecb3ac