### PR TITLE
Add support for packed records and sealed classes

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -33,7 +33,7 @@ type_def:     attributes? class_def
             | alias_def
 
 class_def:   CNAME generic_params? "=" ("public"i)? "static"? "partial"? "abstract"? "class"i CNAME* ("(" type_name ("," type_name)* ")")? class_signature "end"i ";" -> class_def
-record_def:  CNAME generic_params? "=" ("public"i)? "record"i ("(" type_name ")")? class_signature "end"i ";" -> record_def
+record_def:  CNAME generic_params? "=" ("public"i)? "packed"i? "record"i ("(" type_name ")")? class_signature "end"i ";" -> record_def
 interface_def: CNAME generic_params? "=" ("public"i)? "interface"i ("(" type_name ("," type_name)* ")")? class_signature "end"i ";" -> interface_def
 enum_def:    CNAME "=" ("public"i)? ("enum"i | "flags"i)? "(" enum_items ")" ("of" type_name)? ";" -> enum_def
 alias_def:   access_modifier? CNAME generic_params? "=" type_spec ";"     -> alias_def
@@ -318,6 +318,7 @@ ENUM:        "enum"i
 FLAGS:       "flags"i
 EVENT:       "event"i
 OPERATOR:    "operator"i
+PACKED:      "packed"i
 TUPLE:       "tuple"i
 ARRAY:       "array"i
 TYPEOF:      "typeof"i

--- a/tests/PackedRecord.cs
+++ b/tests/PackedRecord.cs
@@ -1,0 +1,6 @@
+namespace Demo {
+    public partial struct PackedRec {
+        // TODO: field X: int -> declare a field
+        public int X;
+    }
+}

--- a/tests/PackedRecord.pas
+++ b/tests/PackedRecord.pas
@@ -1,0 +1,9 @@
+namespace Demo;
+
+type
+  PackedRec = public packed record
+  public
+    X: Integer;
+  end;
+
+end.

--- a/tests/SealedClass.cs
+++ b/tests/SealedClass.cs
@@ -1,5 +1,5 @@
 namespace Demo {
-    public partial class SealedClass {
+    public sealed partial class SealedClass {
         public void DoStuff() {
         }
     }

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -351,6 +351,13 @@ class TranspileTests(unittest.TestCase):
             "// TODO: field B: int -> declare a field",
         ])
 
+    def test_packed_record(self):
+        src = Path('tests/PackedRecord.pas').read_text()
+        expected = Path('tests/PackedRecord.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, ["// TODO: field X: int -> declare a field"])
+
     def test_set_type(self):
         src = Path('tests/SetType.pas').read_text()
         expected = Path('tests/SetType.cs').read_text().strip()

--- a/utils.py
+++ b/utils.py
@@ -20,8 +20,8 @@ def map_type(pas_type: str) -> str:
         "extended": "double",
         "currency": "decimal",
         "comp": "decimal",
-        "char": "Char",
-        "widechar": "Char",
+        "char": "char",
+        "widechar": "char",
         "ansistring": "string",
         "widestring": "string",
         "variant": "object",
@@ -144,6 +144,8 @@ def fix_keyword(tok):
         tok.type = "EVENT"
     elif v == "operator":
         tok.type = "OPERATOR"
+    elif v == "packed":
+        tok.type = "PACKED"
     elif v == "tuple":
         tok.type = "TUPLE"
     elif v == "typeof":


### PR DESCRIPTION
## Summary
- allow `packed record` syntax in the grammar
- detect `sealed`/`final` modifiers on classes
- output `sealed` keyword in generated C# classes
- map Pascal `char` to C# `char`
- adjust ternary operator formatting
- test packed records and sealed classes

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_sealed_class -q`
- `pytest tests/test_transpile.py::TranspileTests::test_packed_record -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d342c382483319a1ff30774efc491