### PR TITLE
Support negative numbers in case labels

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -160,8 +160,9 @@ on_handler: ON CNAME ":" type_name DO stmt -> on_handler
 
 case_stmt:   "case" expr "of" case_branch+ ("else" stmt+)? "end"i ";"? -> case_stmt
 case_branch: case_label ("," case_label)* ":" stmt ";"?
-case_label: NUMBER DOTDOT NUMBER        -> label_range
-          | NUMBER
+signed_number: OP_SUM? NUMBER          -> signed_number
+case_label: signed_number DOTDOT signed_number        -> label_range
+          | signed_number
           | SQ_STRING
           | STRING
           | dotted_name

--- a/tests/NegativeCase.cs
+++ b/tests/NegativeCase.cs
@@ -1,0 +1,11 @@
+namespace N {
+    public partial class TTest {
+        public void Foo(int x) {
+            switch (x)
+            {
+                case -1: Console.WriteLine("neg one"); break;
+                case -2: Console.WriteLine("neg two"); break;
+            }
+        }
+    }
+}

--- a/tests/NegativeCase.pas
+++ b/tests/NegativeCase.pas
@@ -1,0 +1,19 @@
+namespace N;
+
+type
+  TTest = public class
+  public
+    method Foo(x: Integer);
+  end;
+
+implementation
+
+method TTest.Foo(x: Integer);
+begin
+  case x of
+    -1: Console.WriteLine('neg one');
+    -2: Console.WriteLine('neg two');
+  end;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -234,6 +234,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_negative_case(self):
+        src = Path('tests/NegativeCase.pas').read_text()
+        expected = Path('tests/NegativeCase.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_large_case_range(self):
         src = Path('tests/LargeCaseRange.pas').read_text()
         expected = Path('tests/LargeCaseRange.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -913,7 +913,9 @@ class ToCSharp(Transformer):
         return ('branch', labels, stmt)
 
     def case_label(self, tok):
-        return "null" if str(tok) == "nil" else str(tok)
+        if isinstance(tok, Token):
+            return "null" if tok.type == "NIL" else tok.value
+        return str(tok)
 
     def label_range(self, start, _dd, end):
         return ('range', int(str(start)), int(str(end)))
@@ -964,6 +966,17 @@ class ToCSharp(Transformer):
 
     def number(self, n):
         return str(n).replace('_', '').replace(',', '')
+
+    def signed_number(self, *parts):
+        if len(parts) == 2:
+            sign, num = parts
+            sign = str(sign)
+        else:
+            sign, num = '', parts[0]
+        val = int(str(num).replace('_', '').replace(',', ''))
+        if sign == '-':
+            val = -val
+        return val
 
     def hex_number(self, tok):
         return '0x' + tok.value[1:]


### PR DESCRIPTION
## Summary
- extend grammar with a `signed_number` rule
- handle signed numbers when generating C#
- add test covering negative `case` labels

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_negative_case -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d8b97ab888331a231c76a6c0d0a16