### PR TITLE
Fix result identifier parsing

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -16,6 +16,7 @@ name_part: CNAME
          | EVENT
          | OPERATOR
          | TUPLE
+         | RESULT
 
 dotted_name: name_part ("." name_part)* -> dotted
 namespace:   "namespace" dotted_name ";"                       -> namespace

--- a/tests/ResultCall.cs
+++ b/tests/ResultCall.cs
@@ -1,0 +1,14 @@
+namespace Demo {
+    public partial class TRetornoZoom {
+        public void definirMensagem(string a, string b) { /* TODO: implement */ }
+    }
+    
+    public partial class Foo {
+        public TRetornoZoom Response(string body_string) {
+            TRetornoZoom result;
+            result = new TRetornoZoom();
+            result.definirMensagem("00", body_string);
+            return result;
+        }
+    }
+}

--- a/tests/ResultCall.pas
+++ b/tests/ResultCall.pas
@@ -1,0 +1,22 @@
+namespace Demo;
+
+type
+  TRetornoZoom = public class
+  public
+    method definirMensagem(a: String; b: String);
+  end;
+
+  Foo = public class
+  public
+    method Response(body_string: String): TRetornoZoom;
+  end;
+
+implementation
+
+method Foo.Response(body_string: String): TRetornoZoom;
+begin
+  result := new TRetornoZoom;
+  result.definirMensagem("00", body_string);
+end;
+
+end.

--- a/tests/test_user_parse_errors.py
+++ b/tests/test_user_parse_errors.py
@@ -37,3 +37,6 @@ class NewFeatureTests(unittest.TestCase):
 
     def test_if_or(self):
         self.check_pair('IfOr', allow_todos=True)
+
+    def test_result_call(self):
+        self.check_pair('ResultCall')


### PR DESCRIPTION
## Summary
- allow `result` in dotted names so it's parsed as an identifier
- test method calls using the implicit `result` variable

## Testing
- `pip install lark-parser`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d8c2d24cc833190f0f4119c92c5e3