### PR TITLE
Add support for C-style comments

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -361,8 +361,10 @@ CNAME: /&?[A-Za-z_][A-Za-z_0-9]*\??/
 COMMENT_BRACE: /\{(?s:.*?)\}/
 LINE_COMMENT: /\/\/[^\n]*/
 COMMENT_PAREN: /\(\*[\s\S]*?\*\)/
+COMMENT_STAR: /\/\*[\s\S]*?\*\//
 %ignore WS
 %ignore COMMENT_BRACE
 %ignore LINE_COMMENT
 %ignore COMMENT_PAREN
+%ignore COMMENT_STAR
 """

--- a/tests/CStyleComment.cs
+++ b/tests/CStyleComment.cs
@@ -1,0 +1,9 @@
+namespace Demo {
+    public partial class Foo {
+        public int Value() {
+            int result;
+            result = 123;
+            return result;
+        }
+    }
+}

--- a/tests/CStyleComment.pas
+++ b/tests/CStyleComment.pas
@@ -1,0 +1,18 @@
+namespace Demo;
+
+type
+  Foo = class
+  public
+    method Value: Integer;
+  end;
+
+implementation
+
+method Foo.Value: Integer;
+begin
+  /* comment
+     multiple lines */
+  result := 123;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -59,6 +59,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_cstyle_comment(self):
+        src = Path('tests/CStyleComment.pas').read_text()
+        expected = Path('tests/CStyleComment.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_single_stmt(self):
         src = Path('tests/SingleStmt.pas').read_text()
         expected = Path('tests/SingleStmt.cs').read_text().strip()


### PR DESCRIPTION
## Summary
- handle `/* ... */` comments in grammar
- add Pascal/C# pair showing comment usage
- test ignoring of C-style comments during transpile

## Testing
- `pytest -k cstyle_comment -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d8cd718b083319e61a4038b724b12