### PR TITLE
Handle double semicolons

### DIFF
--- a/pas2cs.py
+++ b/pas2cs.py
@@ -4,6 +4,7 @@
 # MIT‑0 licence.  Usage:  python pas2cs.py  InFile.pas  > OutFile.cs
 # ------------------------------------------------------------
 import sys
+import re
 from pathlib import Path
 from lark import Lark
 from grammar import GRAMMAR
@@ -38,6 +39,8 @@ def _get_parser() -> Lark:
 
 def transpile(source: str, manual_translate=None, manual_parse_error=None) -> tuple[str, list[str]]:
     source = source.lstrip('\ufeff')
+    # Collapse accidental double semicolons which can appear in some Pascal code
+    source = re.sub(r';;(?=\s*(?:\n|$))', ';', source)
     set_source(source)
     parser = _get_parser()
     try:

--- a/tests/ExtraSemi.cs
+++ b/tests/ExtraSemi.cs
@@ -1,0 +1,9 @@
+namespace Demo {
+    public partial class ExtraSemi {
+        public static void Demo() {
+            int x;
+            x = 1;
+            x = x + 1;
+        }
+    }
+}

--- a/tests/ExtraSemi.pas
+++ b/tests/ExtraSemi.pas
@@ -1,0 +1,18 @@
+namespace Demo;
+
+type
+  ExtraSemi = public class
+  public
+    class method Demo();
+  end;
+
+implementation
+
+class method ExtraSemi.Demo();
+var x: Integer;
+begin
+  x := 1;;
+  x := x + 1;;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -613,6 +613,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_extra_semi(self):
+        src = Path('tests/ExtraSemi.pas').read_text()
+        expected = Path('tests/ExtraSemi.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_local_const(self):
         src = Path('tests/LocalConst.pas').read_text()
         expected = Path('tests/LocalConst.cs').read_text().strip()


### PR DESCRIPTION
## Summary
- allow Pascal code to contain duplicated semicolons by collapsing them before parsing
- add `ExtraSemi` test case for double-semicolon lines

## Testing
- `pip install lark-parser`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d8f6db7f48331bc96085544342287