### PR TITLE
Handle accented identifiers

### DIFF
--- a/pas2cs.py
+++ b/pas2cs.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from lark import Lark
 from grammar import GRAMMAR
 from transformer import ToCSharp
-from utils import fix_keyword, set_source, safe_print
+from utils import fix_keyword, set_source, safe_print, remove_accents_code
 
 
 def interactive_translate(rule: str, children, line: int) -> str | None:
@@ -41,6 +41,7 @@ def transpile(source: str, manual_translate=None, manual_parse_error=None) -> tu
     source = source.lstrip('\ufeff')
     # Collapse accidental double semicolons which can appear in some Pascal code
     source = re.sub(r';;(?=\s*(?:\n|$))', ';', source)
+    source = remove_accents_code(source)
     set_source(source)
     parser = _get_parser()
     try:

--- a/tests/AccentedName.cs
+++ b/tests/AccentedName.cs
@@ -1,0 +1,6 @@
+namespace Demo {
+    public partial class Importacao {
+        public void DIRF_GravaDetalhes_Importacao(string ano, string mes_filtro) {
+        }
+    }
+}

--- a/tests/AccentedName.pas
+++ b/tests/AccentedName.pas
@@ -1,0 +1,15 @@
+namespace Demo;
+
+type
+  Importacao = class
+  public
+    method DIRF_GravaDetalhes_Importação(ano, mes_filtro: String);
+  end;
+
+implementation
+
+method Importacao.DIRF_GravaDetalhes_Importação(ano, mes_filtro: String);
+begin
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -690,6 +690,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_accented_name(self):
+        src = Path('tests/AccentedName.pas').read_text()
+        expected = Path('tests/AccentedName.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_safe_print_cp1252(self):
         import io, sys
         from utils import safe_print

--- a/transformer.py
+++ b/transformer.py
@@ -954,8 +954,6 @@ class ToCSharp(Transformer):
 
     def if_expr(self, cond, true_expr, false_expr):
         cond_text = str(cond)
-        if not cond_text.startswith('(') and any(c in cond_text for c in ' <>!=&|+-*/%'):
-            cond_text = f"({cond_text})"
         return f"{cond_text} ? {true_expr} : {false_expr}"
 
     def not_expr(self, _tok, expr):
@@ -1212,8 +1210,6 @@ class ToCSharp(Transformer):
 
     def if_expr(self, cond, true_val, false_val):
         cond_text = str(cond)
-        if not cond_text.startswith('(') and any(c in cond_text for c in ' <>!=&|+-*/%'):
-            cond_text = f"({cond_text})"
         return f"{cond_text} ? {true_val} : {false_val}"
 
     def char_code(self, tok):

--- a/utils.py
+++ b/utils.py
@@ -1,9 +1,41 @@
 import textwrap
 import sys
 import locale
+import unicodedata
 # ─────────────────── Utility helpers ─────────────────────────
 def indent(code: str, lvl: int = 1) -> str:
     return textwrap.indent(code, "    " * lvl, lambda _: True)
+
+def remove_accents(text: str) -> str:
+    """Return `text` with any diacritical marks stripped."""
+    nfkd = unicodedata.normalize('NFD', text)
+    return ''.join(ch for ch in nfkd if not unicodedata.combining(ch))
+
+def remove_accents_code(text: str) -> str:
+    """Strip accents from `text` but keep contents of single-quoted strings."""
+    result = []
+    i = 0
+    in_str = False
+    while i < len(text):
+        ch = text[i]
+        if in_str:
+            result.append(ch)
+            if ch == "'":
+                if i + 1 < len(text) and text[i + 1] == "'":
+                    result.append(text[i + 1])
+                    i += 1
+                else:
+                    in_str = False
+            i += 1
+            continue
+        else:
+            if ch == "'":
+                in_str = True
+                result.append(ch)
+            else:
+                result.append(remove_accents(ch))
+            i += 1
+    return ''.join(result)
 
 def map_type(pas_type: str) -> str:
     """Map basic Pascal type names to their C# equivalents."""


### PR DESCRIPTION
## Summary
- support accented identifiers by stripping accents before parsing
- avoid modifying string literals when stripping accents
- generate conditional expressions without extra parentheses
- test accented procedure names

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_accented_name -q`
- `pytest tests/test_transpile.py::TranspileTests::test_ternary_if -q`
- `pytest tests/test_transpile.py::TranspileTests::test_range_words -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d935d13c88331a17d0af618aaee1f