### PR TITLE
Support Pascal-case IF keyword

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -146,7 +146,7 @@ using_stmt: USING CNAME (":" type_spec)? ":=" expr DO stmt       -> using_var
 locking_stmt: LOCKING expr DO stmt                      -> locking_stmt
 with_stmt: WITH expr DO stmt                           -> with_stmt
 yield_stmt: YIELD expr ";"?                           -> yield_stmt
-if_stmt:     "if" expr "then" stmt? ("else" stmt)?        -> if_stmt
+if_stmt:     "if"i expr THEN stmt? (ELSE stmt)?        -> if_stmt
 for_stmt:    "for"i CNAME (":" type_spec)? ":=" expr (TO | DOWNTO) expr (STEP expr)? ("do"i)? stmt  -> for_stmt
            | "for"i "each"i? CNAME (":" type_spec)? IN expr (INDEX CNAME)? ("do"i)? stmt      -> for_each_stmt
 loop_stmt:   LOOP stmt                                       -> loop_stmt
@@ -159,7 +159,7 @@ finally_clause: FINALLY stmt+
 on_handler: ON CNAME ":" type_name DO stmt -> on_handler
           | ON CNAME ":" type_name DO ";" -> on_handler_empty
 
-case_stmt:   "case" expr "of" case_branch+ ("else" stmt+)? "end"i ";"? -> case_stmt
+case_stmt:   "case" expr "of" case_branch+ (ELSE stmt+)? "end"i ";"? -> case_stmt
 case_branch: case_label ("," case_label)* ":" stmt ";"?
 signed_number: OP_SUM? NUMBER          -> signed_number
 case_label: signed_number DOTDOT signed_number        -> label_range
@@ -186,7 +186,7 @@ inherited_stmt: "inherited"i (name_term ("(" arg_list? ")" call_postfix*)?)? ";"
            | expr SHR expr                          -> binop
            | expr OP_SUM ELSE expr                   -> short_or
            | expr OP_MUL THEN expr                   -> short_and
-           | "if" expr "then" expr "else" expr       -> if_expr
+           | "if"i expr THEN expr ELSE expr       -> if_expr
            | expr (OP_REL|LT|GT) expr                -> binop
            | expr IN set_lit                         -> in_expr
            | expr NOT IN set_lit                     -> not_in_expr
@@ -209,7 +209,7 @@ inherited_stmt: "inherited"i (name_term ("(" arg_list? ")" call_postfix*)?)? ";"
            | array_of_expr
            | new_expr
            | anon_proc_expr
-           | "if" expr "then" expr "else" expr         -> if_expr
+           | "if"i expr THEN expr ELSE expr         -> if_expr
            | CHAR_CODE                               -> char_code
            | expr CARET                              -> deref
 

--- a/tests/BugFixes.cs
+++ b/tests/BugFixes.cs
@@ -23,6 +23,9 @@ namespace Demo {
         public void Backslash(string src) {
             src = src.Replace("\\", "\\\\");
         }
+        public void PascalIf(bool flag) {
+            if (flag) System.Console.WriteLine("ok");
+        }
         public void SQPath() {
             System.Console.WriteLine("C:\\temp\\file.txt");
         }

--- a/tests/BugFixes.pas
+++ b/tests/BugFixes.pas
@@ -7,8 +7,9 @@ type
     method PathJoin(nome_arquivo: String);
     method CaseRange(x: Integer);
     method Underscore(ds: Object);
-    method CommaNumber(ds: Object);
-    method Backslash(src: String);
+  method CommaNumber(ds: Object);
+  method Backslash(src: String);
+  method PascalIf(flag: Boolean);
   end;
 
 implementation
@@ -47,6 +48,11 @@ end;
 method BugFixes.Backslash(src: String);
 begin
   src := src.Replace("\", "\\");
+end;
+method BugFixes.PascalIf(flag: Boolean);
+begin
+  If flag then
+    System.Console.WriteLine('ok');
 end;
 
 method BugFixes.SQPath;

--- a/transformer.py
+++ b/transformer.py
@@ -760,7 +760,7 @@ class ToCSharp(Transformer):
     def finalization_section(self, *stmts):
         return ""
 
-    def if_stmt(self, cond, then_block=None, else_block=None):
+    def if_stmt(self, cond, _then=None, then_block=None, _else=None, else_block=None):
         then_part = then_block if then_block is not None else "{}"
         else_part = f" else {else_block}" if else_block else ""
         return f"if ({cond}) {then_part}{else_part}"
@@ -883,6 +883,7 @@ class ToCSharp(Transformer):
     def case_stmt(self, expr, *parts):
         branches = [p for p in parts if isinstance(p, tuple) and p[0] == 'branch']
         else_branch = [p for p in parts if not (isinstance(p, tuple) and p[0] == 'branch')]
+        else_branch = [p for p in else_branch if not (isinstance(p, Token) and p.type == 'ELSE')]
 
         switch_body = []
         for _tag, labels, stmt in branches:
@@ -952,11 +953,8 @@ class ToCSharp(Transformer):
     def short_and(self, left, _and, _then, right):
         return self.binop(left, "and then", right)
 
-    def if_expr(self, cond, true_expr, false_expr):
-        cond_text = str(cond)
-        if not cond_text.startswith('(') and any(c in cond_text for c in ' <>!=&|+-*/%'):
-            cond_text = f"({cond_text})"
-        return f"{cond_text} ? {true_expr} : {false_expr}"
+    def if_expr(self, cond, _then, true_expr, _else, false_expr):
+        return f"{cond} ? {true_expr} : {false_expr}"
 
     def not_expr(self, _tok, expr):
         return f"!{expr}"
@@ -1210,11 +1208,8 @@ class ToCSharp(Transformer):
         sig = self.lambda_sig(params)
         return f"{sig} => {block}"
 
-    def if_expr(self, cond, true_val, false_val):
-        cond_text = str(cond)
-        if not cond_text.startswith('(') and any(c in cond_text for c in ' <>!=&|+-*/%'):
-            cond_text = f"({cond_text})"
-        return f"{cond_text} ? {true_val} : {false_val}"
+    def if_expr(self, cond, _then, true_val, _else, false_val):
+        return f"{cond} ? {true_val} : {false_val}"
 
     def char_code(self, tok):
         nums = [int(n) for n in tok.value[1:].split('#') if n]


### PR DESCRIPTION
## Summary
- allow `If` with a capital I in Pascal code
- adjust `if_expr`, `if_stmt`, and `case_stmt` parsing
- filter `ELSE` token in case statement transformer
- add regression test using Pascal-case `If`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d92ad89e08331abbc3cabd336b418