### PR TITLE
Support assembly attribute parsing

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -1,9 +1,10 @@
 # ────────────────────────── Grammar ──────────────────────────
 GRAMMAR = r"""
-?start:   (namespace | unit_decl | program_decl | library_decl) interface_section? class_section+ ("implementation" uses_clause? class_impl*)? initialization_section? ("end"i ("." | ";"))?
+?start:   assembly_attr* (namespace | unit_decl | program_decl | library_decl) interface_section? class_section+ ("implementation" uses_clause? class_impl*)? initialization_section? ("end"i ("." | ";"))?
 interface_section: "interface" uses_clause? pre_class_decl*
 uses_clause:   "uses" dotted_name ("," dotted_name)* ";"       -> uses
 
+assembly_attr: "[" CNAME ":" dotted_name ("(" arg_list? ")")? "]" ";"?
 
 attribute: "[" dotted_name ("(" arg_list? ")")? "]"
 attributes: attribute+

--- a/tests/AssemblyAttr.cs
+++ b/tests/AssemblyAttr.cs
@@ -1,0 +1,6 @@
+namespace Demo {
+    public partial class AttrDemo {
+        public void DoIt() {
+        }
+    }
+}

--- a/tests/AssemblyAttr.pas
+++ b/tests/AssemblyAttr.pas
@@ -1,0 +1,16 @@
+[assembly: AssemblyTitle('demo')]
+namespace Demo;
+
+type
+  AttrDemo = public class
+  public
+    method DoIt;
+  end;
+
+implementation
+
+method AttrDemo.DoIt;
+begin
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -697,6 +697,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_assembly_attr(self):
+        src = Path('tests/AssemblyAttr.pas').read_text()
+        expected = Path('tests/AssemblyAttr.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_safe_print_cp1252(self):
         import io, sys
         from utils import safe_print

--- a/transformer.py
+++ b/transformer.py
@@ -62,6 +62,9 @@ class ToCSharp(Transformer):
     def attribute(self, *parts):
         return ""
 
+    def assembly_attr(self, *parts):
+        return ""
+
     # ── root rule -------------------------------------------------
     def start(self, ns, *parts):
         classes = []
@@ -953,7 +956,7 @@ class ToCSharp(Transformer):
     def short_and(self, left, _and, _then, right):
         return self.binop(left, "and then", right)
 
-    def if_expr(self, cond, true_expr, false_expr):
+    def if_expr(self, cond, _then_tok, true_expr, _else_tok, false_expr):
         cond_text = str(cond)
         return f"{cond_text} ? {true_expr} : {false_expr}"
 
@@ -1209,7 +1212,7 @@ class ToCSharp(Transformer):
         sig = self.lambda_sig(params)
         return f"{sig} => {block}"
 
-    def if_expr(self, cond, true_val, false_val):
+    def if_expr(self, cond, _then_tok, true_val, _else_tok, false_val):
         cond_text = str(cond)
         return f"{cond_text} ? {true_val} : {false_val}"
 


### PR DESCRIPTION
## Summary
- parse assembly attributes
- handle assembly attributes in transformer
- fix `if_expr` argument mismatch
- test assembly attributes

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_assembly_attr -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d96e60c7c8331b81606696ab3e9e1