### PR TITLE
Fix parser to handle 'partial sealed class'

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -33,7 +33,7 @@ type_def:     attributes? class_def
             | attributes? enum_def
             | alias_def
 
-class_def:   CNAME generic_params? "=" ("public"i)? "static"? "partial"? "abstract"? "class"i ("sealed"i | "final"i)? CNAME* ("(" type_name ("," type_name)* ")")? class_signature "end"i ";" -> class_def
+class_def:   CNAME generic_params? "=" ("public"i)? "static"? "partial"? ("sealed"i | "final"i)? "abstract"? "class"i ("sealed"i | "final"i)? CNAME* ("(" type_name ("," type_name)* ")")? class_signature "end"i ";" -> class_def
 record_def:  CNAME generic_params? "=" ("public"i)? "packed"i? "record"i ("(" type_name ")")? class_signature "end"i ";" -> record_def
 interface_def: CNAME generic_params? "=" ("public"i)? "interface"i ("(" type_name ("," type_name)* ")")? class_signature "end"i ";" -> interface_def
 enum_def:    CNAME "=" ("public"i)? ("enum"i | "flags"i)? "(" enum_items ")" ("of" type_name)? ";" -> enum_def

--- a/pas2cs.py
+++ b/pas2cs.py
@@ -32,6 +32,7 @@ def _get_parser() -> Lark:
             GRAMMAR,
             parser="lalr",
             maybe_placeholders=True,
+            propagate_positions=True,
             lexer_callbacks={"CNAME": fix_keyword},
         )
     return _PARSER

--- a/tests/PartialSealed.cs
+++ b/tests/PartialSealed.cs
@@ -1,0 +1,10 @@
+namespace SGU.Infra.Properties {
+    public partial class Settings : System.Configuration.ApplicationSettingsBase {
+        // TODO: field defaultInstance: Settings -> declare a field
+        public static Settings defaultInstance = System.Configuration.ApplicationSettingsBase.Synchronized(new Settings()) as Settings;
+        public Settings Default { get => get_Default; }
+        public static Settings get_Default() {
+            return defaultInstance;
+        }
+    }
+}

--- a/tests/PartialSealed.pas
+++ b/tests/PartialSealed.pas
@@ -1,0 +1,23 @@
+namespace SGU.Infra.Properties;
+
+interface
+
+type
+  [System.Runtime.CompilerServices.CompilerGeneratedAttribute]
+  [System.CodeDom.Compiler.GeneratedCodeAttribute('Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator', '10.0.0.0')]
+  Settings = partial sealed class(System.Configuration.ApplicationSettingsBase)
+  private
+    class var defaultInstance: Settings := (System.Configuration.ApplicationSettingsBase.Synchronized(new Settings()) as Settings);
+    class method get_Default: Settings;
+  public
+    class property Default: Settings read get_Default;
+  end;
+
+implementation
+
+class method Settings.get_Default: Settings;
+begin
+  exit(defaultInstance);
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -534,6 +534,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_partial_sealed_class(self):
+        src = Path('tests/PartialSealed.pas').read_text()
+        expected = Path('tests/PartialSealed.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, ['// TODO: field defaultInstance: Settings -> declare a field'])
+
     def test_new_stmt(self):
         src = Path('tests/NewStmt.pas').read_text()
         expected = Path('tests/NewStmt.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -1209,7 +1209,7 @@ class ToCSharp(Transformer):
         sig = self.lambda_sig(params)
         return f"{sig} => {block}"
 
-    def if_expr(self, cond, true_val, false_val):
+    def if_expr(self, cond, _then_tok, true_val, _else_tok, false_val):
         cond_text = str(cond)
         return f"{cond_text} ? {true_val} : {false_val}"
 


### PR DESCRIPTION
## Summary
- allow `sealed` modifier before the `class` keyword in `grammar.py`
- keep token positions from Lark with `propagate_positions=True`
- ignore THEN/ELSE tokens when transforming `if` expressions
- add failing example with a `partial sealed` class

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d973fa1188331a3fdf8deec8f1044