### PR TITLE
Support missing type parameters

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -67,6 +67,7 @@ param_block: "(" param_list? ")"                     -> params
 return_block: ":" type_spec                           -> rettype
 param_list:  param (";" param)*
 param:       (VAR|OUT|CONST)? name_list ":" type_spec (":=" expr)? -> param
+            | (VAR|OUT|CONST) name_list (":=" expr)? -> param_untyped
 name_list:   CNAME ("," CNAME)* -> names
 
 type_spec: type_name "?"?                              -> type_spec

--- a/tests/ParamNoType.cs
+++ b/tests/ParamNoType.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class ParamNoType {
+        public DataSet BuscarEspelho(string ano, string mes, string numConta, object indDiferenca) {
+            return default(DataSet);
+        }
+    }
+}

--- a/tests/ParamNoType.pas
+++ b/tests/ParamNoType.pas
@@ -1,0 +1,14 @@
+namespace Demo;
+
+type
+  ParamNoType = public class
+  public
+    function BuscarEspelho(ano, mes, numConta: String; var indDiferenca): DataSet;
+  end;
+
+implementation
+
+function ParamNoType.BuscarEspelho(ano, mes, numConta: String; var indDiferenca): DataSet;
+begin
+end;
+

--- a/tests/test_user_parse_errors.py
+++ b/tests/test_user_parse_errors.py
@@ -40,3 +40,6 @@ class NewFeatureTests(unittest.TestCase):
 
     def test_result_call(self):
         self.check_pair('ResultCall')
+
+    def test_param_no_type(self):
+        self.check_pair('ParamNoType', allow_todos=True)

--- a/transformer.py
+++ b/transformer.py
@@ -403,9 +403,21 @@ class ToCSharp(Transformer):
         parts = list(parts)
         if parts and isinstance(parts[0], Token):
             parts.pop(0)
-        names, ptype = parts[0], parts[1]
-        t = map_type_ext(str(ptype))
+        names = parts.pop(0)
+        ptype = None
+        if parts and not isinstance(parts[0], Token):
+            ptype = parts.pop(0)
+        if ptype is None:
+            t = "object"
+            info = f"// TODO: parameter {', '.join(names)} missing type"
+            self.todo.append(info)
+        else:
+            t = map_type_ext(str(ptype))
         return [f"{t} {self._safe_name(n)}" for n in names]
+
+    def param_untyped(self, *parts):
+        # variant of param rule when no type is declared
+        return self.param(*parts)
 
     def param_list(self, *ps):
         out = []


### PR DESCRIPTION
## Summary
- update grammar to allow VAR parameters without a type
- emit a TODO and default to `object` when a parameter type is omitted
- add tests demonstrating untyped parameter handling

## Testing
- `pytest tests/test_user_parse_errors.py::NewFeatureTests::test_param_no_type -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d9bbb03288331890ca176e6f6dd7b