### PR TITLE
Support nested generics

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -268,7 +268,7 @@ var_decl_infer: name_list ":=" expr ";"                 -> var_decl_infer
 
 LT:           "<"
 GT:           ">"
-GENERIC_ARGS: /<[A-Za-z_][A-Za-z0-9_,\.\s]*>/
+GENERIC_ARGS: /<[A-Za-z_][^<>]*(?:<[^<>]*>[^<>]*)*>/
 OP_SUM:       "+" | "-" | "or" | "xor"i
 OP_MUL:       "*" | "/" | "and" | "mod"i | "div"i
 OP_REL:       "=" | "<>" | "<=" | ">="

--- a/tests/Generics.cs
+++ b/tests/Generics.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using System.Collections;
+using System.IO;
 
 namespace Demo {
     public partial class MyList : List<string> {
@@ -17,6 +18,10 @@ namespace Demo {
         public void Parse(JObject ret) {
             Hashtable aux;
             aux = (ret as JObject).ToObject<Hashtable>();
+        }
+        public void WithNested(Dictionary<string, List<FileInfo>> d) {
+            Dictionary<string, List<FileInfo>> x;
+            x = new Dictionary<string, List<FileInfo>>();
         }
     }
     

--- a/tests/Generics.pas
+++ b/tests/Generics.pas
@@ -2,7 +2,7 @@ namespace Demo;
 
 interface
 
-uses System.Collections.Generic, Newtonsoft.Json.Linq, System.Collections;
+uses System.Collections.Generic, Newtonsoft.Json.Linq, System.Collections, System.IO;
 
 type
   MyList = public class(List<String>)
@@ -14,6 +14,7 @@ type
   public
     method UseList(l: List<String>);
     method Parse(ret: JObject);
+    method WithNested(d: Dictionary<String, List<FileInfo>>);
   end;
 
   GenericStatic = public class
@@ -45,6 +46,13 @@ var
   aux: Hashtable;
 begin
   aux := (ret as JObject).ToObject<Hashtable>();
+end;
+
+method GenExample.WithNested(d: Dictionary<String, List<FileInfo>>);
+var
+  x: Dictionary<String, List<FileInfo>>;
+begin
+  x := new Dictionary<String, List<FileInfo>>;
 end;
 
 class method GenericStatic.Use();


### PR DESCRIPTION
## Summary
- handle generic types that contain another generic type
- add nested generic example to Generics tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ef0d6ae388331a029640808ec6681