### PR TITLE
Support method attributes with named arguments

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -44,7 +44,8 @@ enum_item:   CNAME ("=" NUMBER)?                               -> enum_item
 
 class_signature: member_decl* -> class_sign
 member_decl: attributes? method_decl_rule
-           | attributes? access_modifier? class_modifier? VAR? name_list ":" type_spec (":=" expr)? ";"      -> field_decl
+           | attributes? access_modifier? (CLASSVAR | VAR) attributes? name_list ":" type_spec (":=" expr)? ";"      -> field_decl
+           | access_modifier? name_list ":" type_spec (":=" expr)? ";"      -> field_decl
            | attributes? access_modifier? "class"? "property"i property_sig ";"      -> property_decl
            | attributes? access_modifier? "event"i CNAME ":" type_spec ";"  -> event_decl
            | attributes? access_modifier? "class"? "const"i const_decl+            -> const_block
@@ -79,7 +80,7 @@ type_spec: type_name "?"?                              -> type_spec
            | array_type
            | generic_type
            | dotted_name
-ARRAY_RANGE: /\[(?:[^\[\]]|\[[^\]]*\])*\]/
+ARRAY_RANGE: /\[(?![^\]]*:=)(?:[^\[\]]|\[[^\]]*\])*\]/
 array_type:  "array"i ARRAY_RANGE? "of"i type_name
 
 pointer_type: CARET type_name
@@ -268,7 +269,7 @@ var_decl_infer: name_list ":=" expr ";"                 -> var_decl_infer
 
 LT:           "<"
 GT:           ">"
-GENERIC_ARGS: /<[A-Za-z_][A-Za-z0-9_,\.\s]*>/
+GENERIC_ARGS: /<[A-Za-z_][^<>]*(?:<[^<>]*>[^<>]*)*>/
 OP_SUM:       "+" | "-" | "or" | "xor"i
 OP_MUL:       "*" | "/" | "and" | "mod"i | "div"i
 OP_REL:       "=" | "<>" | "<=" | ">="
@@ -283,6 +284,7 @@ PROCEDURE:   "procedure"i
 FUNCTION:    "function"i
 CONSTRUCTOR: "constructor"i
 DESTRUCTOR:  "destructor"i
+CLASSVAR.2:  /class\s+var/i
 VAR:         "var"i
 OUT:         "out"i
 CONST:       "const"i

--- a/tests/FieldAttr.cs
+++ b/tests/FieldAttr.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class FieldAttr {
+        // TODO: field Field: int -> declare a field
+        [Example(Name = "foo", Order = 1)]
+        public int Field;
+    }
+}

--- a/tests/FieldAttr.pas
+++ b/tests/FieldAttr.pas
@@ -1,0 +1,7 @@
+namespace Demo;
+
+type
+  FieldAttr = public class
+  public
+    var [Example(Name := 'foo', Order := 1)] Field: Integer;
+  end;

--- a/tests/Generics.cs
+++ b/tests/Generics.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using System.Collections;
+using System.IO;
 
 namespace Demo {
     public partial class MyList : List<string> {
@@ -17,6 +18,10 @@ namespace Demo {
         public void Parse(JObject ret) {
             Hashtable aux;
             aux = (ret as JObject).ToObject<Hashtable>();
+        }
+        public void WithNested(Dictionary<string, List<FileInfo>> d) {
+            Dictionary<string, List<FileInfo>> x;
+            x = new Dictionary<string, List<FileInfo>>();
         }
     }
     

--- a/tests/Generics.pas
+++ b/tests/Generics.pas
@@ -2,7 +2,7 @@ namespace Demo;
 
 interface
 
-uses System.Collections.Generic, Newtonsoft.Json.Linq, System.Collections;
+uses System.Collections.Generic, Newtonsoft.Json.Linq, System.Collections, System.IO;
 
 type
   MyList = public class(List<String>)
@@ -14,6 +14,7 @@ type
   public
     method UseList(l: List<String>);
     method Parse(ret: JObject);
+    method WithNested(d: Dictionary<String, List<FileInfo>>);
   end;
 
   GenericStatic = public class
@@ -45,6 +46,13 @@ var
   aux: Hashtable;
 begin
   aux := (ret as JObject).ToObject<Hashtable>();
+end;
+
+method GenExample.WithNested(d: Dictionary<String, List<FileInfo>>);
+var
+  x: Dictionary<String, List<FileInfo>>;
+begin
+  x := new Dictionary<String, List<FileInfo>>;
 end;
 
 class method GenericStatic.Use();

--- a/tests/MethodAttr.cs
+++ b/tests/MethodAttr.cs
@@ -12,4 +12,19 @@ namespace Demo {
             return result;
         }
     }
+    
+    public partial class WebService {
+        [WebMethod(EnableSession = true)]
+        [ScriptMethod]
+        public static string SalvarCadastro(string natrend, string prestserv, string data, string base_calculo, string vl_imposto) {
+            string result;
+            result = "";
+            return result;
+        }
+        public string DescricaoNatRend(object natrend) {
+            string result;
+            result = "";
+            return result;
+        }
+    }
 }

--- a/tests/MethodAttr.pas
+++ b/tests/MethodAttr.pas
@@ -8,6 +8,14 @@ type
     class method Bar(x: Integer): Integer; static;
   end;
 
+  WebService = public class
+  public
+    [WebMethod(EnableSession := true)]
+    [ScriptMethod]
+    class function SalvarCadastro(natrend, prestserv, data, base_calculo, vl_imposto: String): String;
+    function DescricaoNatRend(natrend: Object): String;
+  end;
+
 implementation
 
 class method AttrSample.Foo: Integer;
@@ -19,3 +27,15 @@ class method AttrSample.Bar(x: Integer): Integer;
 begin
   Result := x;
 end;
+
+class function WebService.SalvarCadastro(natrend, prestserv, data, base_calculo, vl_imposto: String): String;
+begin
+  Result := '';
+end;
+
+function WebService.DescricaoNatRend(natrend: Object): String;
+begin
+  Result := '';
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -227,6 +227,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_field_attr(self):
+        src = Path('tests/FieldAttr.pas').read_text()
+        expected = Path('tests/FieldAttr.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, ["// TODO: field Field: int -> declare a field"])
+
     def test_method_conv(self):
         src = Path('tests/MethodConv.pas').read_text()
         expected = Path('tests/MethodConv.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -76,15 +76,29 @@ class ToCSharp(Transformer):
         args = None
         if len(parts) > 1:
             args = parts[1]
-        prev = self.in_attribute
-        self.in_attribute = True
         if args:
-            arg_text = ", ".join(args)
+            pieces = []
+            for a in args:
+                if isinstance(a, tuple) and a[0] == 'named':
+                    pieces.append(f"{a[1]} = {a[2]}")
+                else:
+                    pieces.append(str(a))
+            arg_text = ", ".join(pieces)
             result = f"[{name}({arg_text})]"
         else:
             result = f"[{name}]"
-        self.in_attribute = prev
         return result
+
+    @staticmethod
+    def attribute_visit_wrapper(f, data, children, meta):
+        self = f.__self__
+        prev = self.in_attribute
+        self.in_attribute = True
+        res = f(*children)
+        self.in_attribute = prev
+        return res
+
+    attribute.visit_wrapper = attribute_visit_wrapper
 
     def assembly_attr(self, *parts):
         _assembly = parts[0]
@@ -190,6 +204,10 @@ class ToCSharp(Transformer):
     def class_modifier(self, token=None):
         self.curr_static = True
         return ""
+
+    def CLASSVAR(self, token=None):
+        self.curr_static = True
+        return "var"
 
     # ── module / class ───────────────────────────────────────
     def namespace(self, name):
@@ -501,9 +519,7 @@ class ToCSharp(Transformer):
         return value
 
     def named_arg(self, name, expr):
-        if self.in_attribute:
-            return f"{name} = {expr}"
-        return expr
+        return ('named', str(name), expr)
 
     def method_decl(self, *parts):
         for p in parts:
@@ -566,7 +582,18 @@ class ToCSharp(Transformer):
     def field_decl(self, *parts):
         is_static = self.curr_static
         self.curr_static = False
-        items = [p for p in parts if p not in ("", "var")]
+        attrs = []
+        items = []
+        for p in parts:
+            if p in ("", "var"):
+                continue
+            if isinstance(p, list):
+                if p and str(p[0]).startswith('['):
+                    attrs.extend(p)
+                    continue
+                items.append(p)
+                continue
+            items.append(p)
         if len(items) == 3:
             names, typ, expr = items
         else:
@@ -580,6 +607,8 @@ class ToCSharp(Transformer):
         self.todo.append(info)
         if self.curr_class:
             self.class_fields[self.curr_class].update(names)
+        if attrs:
+            return info + "\n" + "\n".join(attrs + [impl])
         return info + "\n" + impl
 
     def property_sig(self, name, *parts):
@@ -1145,6 +1174,7 @@ class ToCSharp(Transformer):
         first_args = []
         if parts and isinstance(parts[0], list):
             first_args = parts.pop(0)
+        first_args = [a[2] if isinstance(a, tuple) and a[0]=='named' else a for a in first_args]
         call = str(fn)
         if ' as ' in call and (first_args or parts):
             call = f"({call})"
@@ -1192,24 +1222,26 @@ class ToCSharp(Transformer):
                     if args is None:
                         call += f".{name}"
                     else:
+                        args = [a[2] if isinstance(a, tuple) and a[0]=='named' else a for a in args]
                         call += f".{name}({', '.join(args)})"
                 elif kind == 'index':
                     call += part[1]
             elif isinstance(part, Token) and part.type == 'GENERIC_ARGS':
-                if call.endswith("()"): 
+                if call.endswith("()"):
                     call = call[:-2] + part.value + "()"
                     if i < len(parts) and isinstance(parts[i], list):
                         i += 1
                 else:
                     call += part.value
                     if i < len(parts) and isinstance(parts[i], list):
-                        call += f"({', '.join(parts[i])})"
+                        extra = [a[2] if isinstance(a, tuple) and a[0]=='named' else a for a in parts[i]]
+                        call += f"({', '.join(extra)})"
                         i += 1
             else:
                 name = part
                 arglist = []
                 if i < len(parts) and isinstance(parts[i], list):
-                    arglist = parts[i]
+                    arglist = [a[2] if isinstance(a, tuple) and a[0]=='named' else a for a in parts[i]]
                     i += 1
                 call += f".{name}({', '.join(arglist)})"
         return call


### PR DESCRIPTION
## Summary
- add dedicated CLASSVAR token to handle `class var` fields
- adjust member parsing to avoid conflicts with methods
- update transpiler to recognize `CLASSVAR` and mark static fields
- extend MethodAttr example with a method using attributes with named arguments

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_class_var -q`
- `pytest tests/test_transpile.py::TranspileTests::test_method_attr -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ef0d6ae388331a029640808ec6681