### PR TITLE
Handle assembly attributes after uses clause

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -1,7 +1,7 @@
 # ────────────────────────── Grammar ──────────────────────────
 GRAMMAR = r"""
 ?start:   assembly_attr* (namespace | unit_decl | program_decl | library_decl) interface_section? class_section* ("implementation" uses_clause? class_impl*)? initialization_section? ("end"i ("." | ";"))?
-interface_section: "interface" uses_clause? pre_class_decl*
+interface_section: "interface" uses_clause? assembly_attr* pre_class_decl*
 uses_clause:   "uses" dotted_name ("," dotted_name)* ";"       -> uses
 
 assembly_attr: "[" CNAME ":" dotted_name ("(" arg_list? ")")? "]" ";"?

--- a/tests/AssemblyAttr.cs
+++ b/tests/AssemblyAttr.cs
@@ -1,4 +1,6 @@
 [assembly: AssemblyTitle("demo")]
+[assembly: AssemblyDescription("desc")]
+using System.Reflection;
 
 namespace Demo {
     public partial class AttrDemo {

--- a/tests/AssemblyAttr.pas
+++ b/tests/AssemblyAttr.pas
@@ -1,6 +1,13 @@
 [assembly: AssemblyTitle('demo')]
 namespace Demo;
 
+interface
+
+uses
+  System.Reflection;
+
+[assembly: AssemblyDescription('desc')]
+
 type
   AttrDemo = public class
   public


### PR DESCRIPTION
## Summary
- support `[assembly: ...]` inside interface section
- update assembly attribute sample to show attributes after `uses`
- adjust expected C# output accordingly

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_assembly_attr -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862754638948331bcde311ba003daab