### PR TITLE
Handle '=' default parameter syntax

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -68,8 +68,8 @@ method_name: CNAME ("." CNAME)+ GENERIC_ARGS?        -> dotted_method
 param_block: "(" param_list? ")"                     -> params
 return_block: ":" type_spec                           -> rettype
 param_list:  param (";" param)*
-param:       (VAR|OUT|CONST)? name_list ":" type_spec (":=" expr)? -> param
-            | (VAR|OUT|CONST) name_list (":=" expr)? -> param_untyped
+param:       (VAR|OUT|CONST)? name_list ":" type_spec ((OP_REL["="] | ":=") expr)? -> param
+            | (VAR|OUT|CONST) name_list ((OP_REL["="] | ":=") expr)? -> param_untyped
 name_list:   CNAME ("," CNAME)* -> names
 
 type_spec: type_name "?"?                              -> type_spec

--- a/tests/Defaults.cs
+++ b/tests/Defaults.cs
@@ -1,6 +1,8 @@
 namespace Demo {
     public partial class Defaults {
-        public void Test(int a, int b) {
+        public void Test(int a, int b = 1) {
+        }
+        public void TestEq(string a = "") {
         }
     }
 }

--- a/tests/Defaults.pas
+++ b/tests/Defaults.pas
@@ -4,11 +4,17 @@ type
   Defaults = public class
   public
     procedure Test(var a: Integer; b: Integer := 1);
+    procedure TestEq(a: String = '');
   end;
 
 implementation
 
 procedure Defaults.Test(var a: Integer; b: Integer := 1);
+begin
+  inherited;
+end;
+
+procedure Defaults.TestEq(a: String = '');
 begin
   inherited;
 end;

--- a/transformer.py
+++ b/transformer.py
@@ -483,14 +483,23 @@ class ToCSharp(Transformer):
             parts.pop(0)
         names = parts.pop(0)
         ptype = None
+        default_val = None
         if parts and not isinstance(parts[0], Token):
             ptype = parts.pop(0)
+        if parts:
+            # skip '=' or ':=' token if present
+            if isinstance(parts[0], Token):
+                parts.pop(0)
+            if parts:
+                default_val = parts.pop(0)
         if ptype is None:
             t = "object"
             info = f"// TODO: parameter {', '.join(names)} missing type"
             self.todo.append(info)
         else:
             t = map_type_ext(str(ptype))
+        if default_val is not None:
+            return [f"{t} {self._safe_name(n)} = {default_val}" for n in names]
         return [f"{t} {self._safe_name(n)}" for n in names]
 
     def param_untyped(self, *parts):


### PR DESCRIPTION
## Summary
- parse default parameters written with `=`
- include default value in generated C# params
- test parsing of `=` default parameters

## Testing
- `pytest -q tests/test_transpile.py::TranspileTests::test_param_defaults`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68627369fa608331b937a8a8395eb808