### PR TITLE
Allow 'uses' before interface

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -1,6 +1,6 @@
 # ────────────────────────── Grammar ──────────────────────────
 GRAMMAR = r"""
-?start:   assembly_attr* (namespace | unit_decl | program_decl | library_decl) (interface_section | pre_class_decl*)? class_section* ("implementation" uses_clause? class_impl*)? (main_block "." | initialization_section? ("end"i ("." | ";"))?)
+?start:   assembly_attr* (namespace | unit_decl | program_decl | library_decl) uses_clause? (interface_section | pre_class_decl*)? class_section* ("implementation" uses_clause? class_impl*)? (main_block "." | initialization_section? ("end"i ("." | ";"))?)
 main_block: "begin" stmt* "end"i
 interface_section: "interface" uses_clause? assembly_attr* pre_class_decl*
 uses_clause:   "uses" dotted_name ("," dotted_name)* ";"       -> uses

--- a/tests/UsesBeforeInterface.cs
+++ b/tests/UsesBeforeInterface.cs
@@ -1,0 +1,7 @@
+using System.Collections;
+
+namespace Demo {
+    public partial class UsesBeforeInterface {
+    
+    }
+}

--- a/tests/UsesBeforeInterface.pas
+++ b/tests/UsesBeforeInterface.pas
@@ -1,0 +1,13 @@
+namespace Demo;
+
+uses System.Collections;
+
+interface
+
+type
+  UsesBeforeInterface = public class
+  end;
+
+implementation
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -191,6 +191,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_uses_before_interface(self):
+        src = Path('tests/UsesBeforeInterface.pas').read_text()
+        expected = Path('tests/UsesBeforeInterface.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_ctor_impl_no_name(self):
         src = Path('tests/CtorImplNoName.pas').read_text()
         expected = Path('tests/CtorImplNoName.cs').read_text().strip()


### PR DESCRIPTION
## Summary
- extend grammar to accept `uses` right after the namespace header
- add regression test for uses before the `interface` section

## Testing
- `pip install lark-parser`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686278f2e574833181ad3dea5f0571ce