### PR TITLE
Add 'implements' support

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -59,6 +59,7 @@ class_modifier: "class"
 method_attr: "override" | "static" | "abstract" | "virtual" | "reintroduce"i | "overload"i
            | "inline"i | "cdecl"i | "stdcall"i | "safecall"i | "varargs"i
            | "external"i | "forward"i | "platform"i | "deprecated"i | "message"i
+           | "implements" dotted_name
 method_kind: METHOD | PROCEDURE | FUNCTION | CONSTRUCTOR | DESTRUCTOR | OPERATOR
 access_modifier: ("strict"i)? ("public"i | "protected"i | "private"i | "published"i)
 

--- a/missing_features.txt
+++ b/missing_features.txt
@@ -37,7 +37,6 @@ goto
 greaterthan
 greaterthanorequal
 helper
-implements
 implicit
 inc
 inline

--- a/tests/ImplementsAttr.cs
+++ b/tests/ImplementsAttr.cs
@@ -1,0 +1,9 @@
+namespace Demo {
+    public partial class TestClass : IMyInterface {
+        public int IMyInterface_Foo(int a) {
+            int result;
+            result = a;
+            return result;
+        }
+    }
+}

--- a/tests/ImplementsAttr.pas
+++ b/tests/ImplementsAttr.pas
@@ -1,0 +1,16 @@
+namespace Demo;
+
+type
+  TestClass = public class(IMyInterface)
+  private
+    method IMyInterface_Foo(a: Integer): Integer; implements IMyInterface.Foo;
+  end;
+
+implementation
+
+method TestClass.IMyInterface_Foo(a: Integer): Integer;
+begin
+  result := a;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -746,6 +746,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_implements_attr(self):
+        src = Path('tests/ImplementsAttr.pas').read_text()
+        expected = Path('tests/ImplementsAttr.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_assembly_attr(self):
         src = Path('tests/AssemblyAttr.pas').read_text()
         expected = Path('tests/AssemblyAttr.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -340,7 +340,7 @@ class ToCSharp(Transformer):
         if parts and isinstance(parts[0], str) and parts[0].startswith('<'):
             generics = parts[0]
             parts = parts[1:]
-        if parts and isinstance(parts[0], list):
+        if len(parts) > 1 and isinstance(parts[0], list):
             bases = parts[0]
             sign = parts[1]
         elif len(parts) == 2:


### PR DESCRIPTION
## Summary
- support interface method mappings via `implements` clauses
- handle interfaces without bases in transformer
- test new behaviour
- remove `implements` from missing features list

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_implements_attr -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628a9a159883319edacfabd1b3c742