### PR TITLE
Fix semicolon-only lines in preprocessing

### DIFF
--- a/pas2cs.py
+++ b/pas2cs.py
@@ -40,8 +40,9 @@ def _get_parser() -> Lark:
 
 def transpile(source: str, manual_translate=None, manual_parse_error=None) -> tuple[str, list[str]]:
     source = source.lstrip('\ufeff')
-    # Collapse accidental double semicolons which can appear in some Pascal code
-    source = re.sub(r';\s*;(?=\s*(?:\n|$))', ';', source)
+    # Collapse accidental double semicolons and join lone semicolon lines
+    source = re.sub(r'\n\s*;\s*(?=\n)', ';\n', source)
+    source = re.sub(r';\s*(?:;\s*)*(?=\s*(?:\n|$))', ';', source)
     source = re.sub(r'^\s*;\s*(?=\n)', '', source, flags=re.MULTILINE)
     source = remove_accents_code(source)
     set_source(source)

--- a/tests/ExtraSemi.cs
+++ b/tests/ExtraSemi.cs
@@ -2,6 +2,8 @@ namespace Demo {
     public partial class ExtraSemi {
         public static void Demo() {
             int x;
+            int y;
+            string z;
             x = 1;
             x = x + 1;
         }

--- a/tests/ExtraSemi.pas
+++ b/tests/ExtraSemi.pas
@@ -9,7 +9,12 @@ type
 implementation
 
   class method ExtraSemi.Demo();
-  var x: Integer;
+  var
+    x: Integer;
+    y: Integer
+    ;
+    z: String
+    ;
   begin
   x := 1;;
   ;


### PR DESCRIPTION
## Summary
- handle Pascal code that puts semicolons on their own line
- extend semicolon test coverage

## Testing
- `pytest -k extra_semi -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68628b37ac588331b92e8f0f8b4af184