### PR TITLE
Support attributes on implementation methods

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -107,8 +107,8 @@ pre_class_decl: const_block
               | var_section
               | method_decl_rule
 
-class_impl:  class_modifier? method_kind method_impl
-method_impl: impl_head ";" method_decls? block               -> m_impl
+class_impl:  attributes? class_modifier? method_kind method_impl
+method_impl: attributes? impl_head ";" method_decls? block               -> m_impl
 method_decls: (var_section | const_block)+
 impl_head:   method_name param_block? return_block?
 

--- a/tests/MethodAttr.cs
+++ b/tests/MethodAttr.cs
@@ -21,6 +21,7 @@ namespace Demo {
             result = "";
             return result;
         }
+        [WebMethod]
         public string DescricaoNatRend(object natrend) {
             string result;
             result = "";

--- a/tests/MethodAttr.pas
+++ b/tests/MethodAttr.pas
@@ -13,7 +13,7 @@ type
     [WebMethod(EnableSession := true)]
     [ScriptMethod]
     class function SalvarCadastro(natrend, prestserv, data, base_calculo, vl_imposto: String): String;
-    function DescricaoNatRend(natrend: Object): String;
+function DescricaoNatRend(natrend: Object): String;
   end;
 
 implementation
@@ -33,6 +33,7 @@ begin
   Result := '';
 end;
 
+[WebMethod]
 function WebService.DescricaoNatRend(natrend: Object): String;
 begin
   Result := '';


### PR DESCRIPTION
## Summary
- allow attributes before method implementations in grammar
- preserve attributes when generating method bodies
- test attribute handling on implementations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ba55bde88331aa105f9663d42fcc