### PR TITLE
Handle Oxygene event raise syntax

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -49,7 +49,7 @@ member_decl: attributes? method_decl_rule
            | access_modifier? name_list ":" type_spec (":=" expr)? ";"      -> field_decl
 
            | attributes? access_modifier? "class"? "property"i property_sig ";"      -> property_decl
-           | attributes? access_modifier? "event"i CNAME ":" type_spec ";"  -> event_decl
+           | attributes? access_modifier? "event"i CNAME ":" type_spec event_end  -> event_decl
            | attributes? access_modifier? "class"? "const"i const_decl+            -> const_block
            | access_modifier                                   -> section
 
@@ -99,6 +99,10 @@ nullable_type: NULLABLE type_name
 generic_params: "<" CNAME ("," CNAME)* ">"
 
 property_sig: CNAME property_index? ":" type_spec (READ CNAME)? (WRITE CNAME?)? -> property_sig
+event_opt: access_modifier? RAISE -> event_raise
+         | method_attr -> event_attr
+event_end: ";" -> event_simple
+         | event_opt (";" event_opt)* ";" -> event_full
 property_index: "[" param_list? "]"
 const_decl: CNAME (":" type_spec)? OP_REL expr ";"
 const_block: "const" const_decl+

--- a/tests/EventRaise.cs
+++ b/tests/EventRaise.cs
@@ -1,0 +1,8 @@
+using System.ComponentModel;
+
+namespace Demo {
+    public partial class MyClass {
+        // TODO: event PropertyChanged: System.ComponentModel.PropertyChangedEventHandler -> implement
+        public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+    }
+}

--- a/tests/EventRaise.pas
+++ b/tests/EventRaise.pas
@@ -1,0 +1,15 @@
+namespace Demo;
+
+interface
+
+uses System.ComponentModel;
+
+type
+  MyClass = public class
+  public
+    event PropertyChanged: System.ComponentModel.PropertyChangedEventHandler protected raise; virtual;
+  end;
+
+implementation
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -442,6 +442,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, ["// TODO: event OnSomething: EventHandler -> implement"])
 
+    def test_event_raise(self):
+        src = Path('tests/EventRaise.pas').read_text()
+        expected = Path('tests/EventRaise.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, ["// TODO: event PropertyChanged: System.ComponentModel.PropertyChangedEventHandler -> implement"])
+
     def test_field_initializer(self):
         src = Path('tests/FieldInit.pas').read_text()
         expected = Path('tests/FieldInit.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -677,6 +677,19 @@ class ToCSharp(Transformer):
     def property_index(self, *args):
         return []
 
+    # Ignore event option nodes
+    def event_raise(self, *args):
+        return None
+
+    def event_attr(self, *args):
+        return None
+
+    def event_full(self, *args):
+        return None
+
+    def event_simple(self, *args):
+        return None
+
     def property_decl(self, *parts):
         sig = parts[-1]
         name, typ, getter, setter = sig
@@ -685,8 +698,13 @@ class ToCSharp(Transformer):
         return impl
 
     def event_decl(self, *parts):
-        name = self._safe_name(parts[-2])
-        typ = map_type_ext(str(parts[-1]))
+        # parts: [attributes?, access_modifier?, name, type_spec, event_end]
+        if len(parts) >= 4:
+            name = self._safe_name(parts[-3])
+            typ = map_type_ext(str(parts[-2]))
+        else:
+            name = self._safe_name(parts[-2])
+            typ = map_type_ext(str(parts[-1]))
         info = f"// TODO: event {name}: {typ} -> implement"
         impl = f"public event {typ} {name};"
         self.todo.append(info)


### PR DESCRIPTION
## Summary
- allow events to specify a `protected raise` block
- ignore event option nodes in transformer
- test event declarations with `raise` and `virtual`

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_event_raise -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ba2f3aa08331bb7a27ecbba5194b