### PR TITLE
Fix parse error line numbers

### DIFF
--- a/pas2cs.py
+++ b/pas2cs.py
@@ -40,9 +40,11 @@ def _get_parser() -> Lark:
 
 def transpile(source: str, manual_translate=None, manual_parse_error=None) -> tuple[str, list[str]]:
     source = source.lstrip('\ufeff')
-    # Collapse accidental double semicolons and join lone semicolon lines
+    # Collapse accidental double semicolons. For lines that consist solely of a
+    # semicolon we strip the semicolon but keep the line break so error
+    # positions still match the original source.
     source = re.sub(r'\n\s*;\s*(?=\n)', ';\n', source)
-    source = re.sub(r';\s*(?:;\s*)*(?=\s*(?:\n|$))', ';', source)
+    source = re.sub(r';[ \t;]*(?=\n|$)', ';', source)
     source = re.sub(r'^\s*;\s*(?=\n)', '', source, flags=re.MULTILINE)
     source = remove_accents_code(source)
     set_source(source)

--- a/tests/BadSyntax.pas
+++ b/tests/BadSyntax.pas
@@ -1,4 +1,18 @@
 namespace Foo;
-interface
-uses
 
+type
+  Example = public class
+  public
+    class method Demo();
+  end;
+
+implementation
+
+  class method Example.Demo();
+  begin
+  x := 1;;
+  ;
+  ???
+  end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -655,6 +655,12 @@ class TranspileTests(unittest.TestCase):
             transpile(src)
         self.assertIn('Parse error', str(cm.exception))
 
+    def test_error_line_numbers(self):
+        src = Path('tests/BadSyntax.pas').read_text()
+        with self.assertRaises(SyntaxError) as cm:
+            transpile(src)
+        self.assertIn('line 15', str(cm.exception))
+
     def test_semicolon_cases(self):
         src = Path('tests/SemicolonCases.pas').read_text()
         expected = Path('tests/SemicolonCases.cs').read_text().strip()


### PR DESCRIPTION
## Summary
- retain newline mapping when preprocessing semicolon lines
- update BadSyntax test input and add check for error line numbers

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_error_line_numbers -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862be65300c833192b53dbf1b260a65