### PR TITLE
Handle empty if branches

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -158,7 +158,8 @@ using_stmt: USING CNAME (":" type_spec)? ":=" expr DO stmt       -> using_var
 locking_stmt: LOCKING expr DO stmt                      -> locking_stmt
 with_stmt: WITH expr DO stmt                           -> with_stmt
 yield_stmt: YIELD expr ";"?                           -> yield_stmt
-if_stmt:     "if"i expr THEN stmt? (ELSE stmt)?        -> if_stmt
+empty_stmt: ";"                                      -> empty
+if_stmt:     "if"i expr THEN (stmt | empty_stmt)? (ELSE stmt)?        -> if_stmt
 for_stmt:    "for"i CNAME (":" type_spec)? ":=" expr (TO | DOWNTO) expr (STEP expr)? ("do"i)? stmt  -> for_stmt
            | "for"i "each"i? CNAME (":" type_spec)? IN expr (INDEX CNAME)? ("do"i)? stmt      -> for_each_stmt
 loop_stmt:   LOOP stmt                                       -> loop_stmt

--- a/tests/IfThenSemi.cs
+++ b/tests/IfThenSemi.cs
@@ -1,0 +1,12 @@
+namespace Demo {
+    public partial class IfThenSemi {
+        public static void Demo(bool flag) {
+            if (flag) {
+                if (flag) {}
+                {
+                    System.Console.WriteLine("Hello");
+                }
+            }
+        }
+    }
+}

--- a/tests/IfThenSemi.pas
+++ b/tests/IfThenSemi.pas
@@ -1,0 +1,22 @@
+namespace Demo;
+
+type
+  IfThenSemi = class
+  public
+    class method Demo(flag: Boolean);
+  end;
+
+implementation
+
+class method IfThenSemi.Demo(flag: Boolean);
+begin
+  if flag then
+  begin
+    if flag then; // no-op
+    begin
+      System.Console.WriteLine('Hello');
+    end;
+  end;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -669,6 +669,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_if_then_semi(self):
+        src = Path('tests/IfThenSemi.pas').read_text()
+        expected = Path('tests/IfThenSemi.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_local_const(self):
         src = Path('tests/LocalConst.pas').read_text()
         expected = Path('tests/LocalConst.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -955,7 +955,10 @@ class ToCSharp(Transformer):
         return ""
 
     def if_stmt(self, cond, _then=None, then_block=None, _else=None, else_block=None):
-        then_part = then_block if then_block is not None else "{}"
+        if then_block is None or not str(then_block).strip():
+            then_part = "{}"
+        else:
+            then_part = then_block
         else_part = f" else {else_block}" if else_block else ""
         return f"if ({cond}) {then_part}{else_part}"
 


### PR DESCRIPTION
## Summary
- allow `if ... then ;` by parsing an empty statement
- map empty THEN blocks to `{}` in generated C#
- test empty `if` handling

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_if_then_semi -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862c165f8888331bb24560c45e6deb2