### PR TITLE
Add assembly protected parsing

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -61,7 +61,13 @@ method_attr: "override" | "static" | "abstract" | "virtual" | "reintroduce"i | "
            | "external"i | "forward"i | "platform"i | "deprecated"i | "message"i
            | "implements" dotted_name
 method_kind: METHOD | PROCEDURE | FUNCTION | CONSTRUCTOR | DESTRUCTOR | OPERATOR
-access_modifier: ("strict"i)? ("public"i | "protected"i | "private"i | "published"i)
+access_modifier: "strict"i? ("public"i
+  | "protected"i
+  | "private"i
+  | "published"i
+  | ASSEMBLY
+  | ASSEMBLY ANDKW "protected"i
+  | "protected"i ANDKW ASSEMBLY)
 
 method_sig:    method_name param_block? return_block?            -> m_sig
              | param_block? return_block?                        -> m_sig_no_name
@@ -285,6 +291,8 @@ var_decl_infer: name_list ":=" expr ";"                 -> var_decl_infer
 LT:           "<"
 GT:           ">"
 GENERIC_ARGS: /<[A-Za-z_][^<>]*(?:<[^<>]*>[^<>]*)*>/
+ASSEMBLY.3:  "assembly"i
+ANDKW.3:     "and"i
 OP_SUM:       "+" | "-" | "or" | "xor"i
 OP_MUL:       "*" | "/" | "and" | "mod"i | "div"i
 OP_REL:       "=" | "<>" | "<=" | ">="

--- a/tests/AssemblyProtected.cs
+++ b/tests/AssemblyProtected.cs
@@ -1,0 +1,8 @@
+namespace Demo {
+    public partial class Foo {
+        public void Hidden() {
+        }
+        public void Create() {
+        }
+    }
+}

--- a/tests/AssemblyProtected.pas
+++ b/tests/AssemblyProtected.pas
@@ -1,0 +1,23 @@
+namespace Demo;
+
+interface
+
+type
+  Foo = public class
+  assembly
+    method Hidden;
+  assembly and protected
+    constructor;
+  end;
+
+implementation
+
+method Foo.Hidden;
+begin
+end;
+
+constructor Foo;
+begin
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -767,6 +767,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_assembly_protected(self):
+        src = Path('tests/AssemblyProtected.pas').read_text()
+        expected = Path('tests/AssemblyProtected.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_safe_print_cp1252(self):
         import io, sys
         from utils import safe_print

--- a/transformer.py
+++ b/transformer.py
@@ -573,7 +573,7 @@ class ToCSharp(Transformer):
         self.curr_kind = str(token) if token else None
         return ""
 
-    def access_modifier(self, token=None):
+    def access_modifier(self, *tokens):
         return ""
 
     def method_attr(self, token=None):


### PR DESCRIPTION
## Summary
- support `assembly and protected` access modifiers
- allow `access_modifier` rule to accept combinations in grammar
- accept multiple tokens for `access_modifier` in transformer
- test new behavior with `AssemblyProtected` example

## Testing
- `pytest -k assembly_protected -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c1e7214c8331a1e30aafa3146c8a