### PR TITLE
Enable array cast property access

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -256,6 +256,7 @@ literal_string: STRING -> string
 call_expr:   var_ref "(" arg_list? ")" call_postfix* -> call
            | generic_call_base ("(" arg_list? ")")? call_postfix* -> call
            | new_expr "." name_term GENERIC_ARGS? call_args? call_postfix* -> call
+           | array_of_expr prop_call call_postfix* -> call
            | "(" expr ")" "." name_term GENERIC_ARGS? call_args? call_postfix* -> call
            | literal_string "." name_term GENERIC_ARGS? call_args? call_postfix* -> call
            | "inherited"i name_term GENERIC_ARGS? call_args? call_postfix* -> inherited_call_expr
@@ -264,6 +265,7 @@ call_expr:   var_ref "(" arg_list? ")" call_postfix* -> call
 call_lhs:   var_ref "(" arg_list? ")" call_postfix+                 -> call
            | generic_call_base ("(" arg_list? ")")? call_postfix+    -> call
            | new_expr "." name_term GENERIC_ARGS? call_args? call_postfix+ -> call
+           | array_of_expr prop_call call_postfix+ -> call
            | "(" expr ")" "." name_term GENERIC_ARGS? call_args? call_postfix+ -> call
            | literal_string "." name_term GENERIC_ARGS? call_args? call_postfix+ -> call
            | typeof_expr call_postfix+                                 -> call

--- a/tests/ArrayCast.cs
+++ b/tests/ArrayCast.cs
@@ -4,5 +4,10 @@ namespace Demo {
             int[] arr;
             arr = new int[]{1, 2, 3};
         }
+        public static int Len() {
+            int result;
+            result = new byte[]{1, 2, 3}.Length;
+            return result;
+        }
     }
 }

--- a/tests/ArrayCast.pas
+++ b/tests/ArrayCast.pas
@@ -4,6 +4,7 @@ type
   ArrayCast = class
   public
     class method Create;
+    class method Len: Integer;
   end;
 
 implementation
@@ -13,6 +14,11 @@ var
   arr: array of Integer;
 begin
   arr := array of Integer([1, 2, 3]);
+end;
+
+class method ArrayCast.Len: Integer;
+begin
+  result := array of Byte([1, 2, 3]).Length;
 end;
 
 end.


### PR DESCRIPTION
## Summary
- allow `array of` cast followed by property access
- test property access on array cast

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_array_cast -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862c2eea51483318ee52043b3f75c43