### PR TITLE
Fix case-insensitive parsing of Case statements

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -178,7 +178,7 @@ finally_clause: FINALLY stmt+
 on_handler: ON CNAME ":" type_name DO stmt -> on_handler
           | ON CNAME ":" type_name DO ";" -> on_handler_empty
 
-case_stmt:   "case" expr "of" case_branch+ case_else? "end"i ";"? -> case_stmt
+case_stmt:   "case"i expr "of"i case_branch+ case_else? "end"i ";"? -> case_stmt
 case_else:   ELSE stmt+                           -> case_else
            | ELSE ";"?                          -> case_else_empty
 case_branch: case_label ("," case_label)* ":" stmt ";"?

--- a/tests/CaseUpper.cs
+++ b/tests/CaseUpper.cs
@@ -1,0 +1,13 @@
+namespace N {
+    public partial class TTest {
+        public string Foo(string val) {
+            string result;
+            switch (val)
+            {
+                case 'S': result = "one"; break;
+                case 'B': result = "two"; break;
+            }
+            return result;
+        }
+    }
+}

--- a/tests/CaseUpper.pas
+++ b/tests/CaseUpper.pas
@@ -1,0 +1,21 @@
+namespace N;
+
+interface
+
+type
+  TTest = public class
+  public
+    method Foo(val: String): String;
+  end;
+
+implementation
+
+method TTest.Foo(val: String): String;
+begin
+  Case val of
+    'S': result := 'one';
+    'B': result := 'two';
+  end;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -262,6 +262,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_case_upper(self):
+        src = Path('tests/CaseUpper.pas').read_text()
+        expected = Path('tests/CaseUpper.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_negative_case(self):
         src = Path('tests/NegativeCase.pas').read_text()
         expected = Path('tests/NegativeCase.cs').read_text().strip()

--- a/utils.py
+++ b/utils.py
@@ -136,6 +136,7 @@ KEYWORD_MAP = {
     "threadvar": "THREADVAR",
     "is": "IS",
     "as": "AS",
+    "case": "CASE",
     "program": "PROGRAM",
     "initialization": "INITIALIZATION",
     "finalization": "FINALIZATION",


### PR DESCRIPTION
## Summary
- add `case` keyword to `KEYWORD_MAP`
- make `case` grammar rule case-insensitive
- add regression test for mixed‑case `Case`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d1cc39a48331bb1bd54743204197