### PR TITLE
Add support for exception handlers without variable

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -176,11 +176,13 @@ loop_stmt:   LOOP stmt                                       -> loop_stmt
 while_stmt:  "while"i expr "do"i stmt                    -> while_stmt
 
 try_stmt:    TRY stmt* except_clause? finally_clause? "end"i ";"? -> try_stmt
-except_clause: EXCEPT (on_handler | stmt)*                       -> except_clause
+except_clause: EXCEPT (on_handler | on_handler_type | stmt)*     -> except_clause
              | EXCEPT ";"                                   -> except_empty
 finally_clause: FINALLY stmt*
 on_handler: ON CNAME ":" type_name DO stmt -> on_handler
           | ON CNAME ":" type_name DO ";" -> on_handler_empty
+on_handler_type: ON type_name DO stmt -> on_handler_type
+               | ON type_name DO ";" -> on_handler_type_empty
 
 case_stmt:   "case"i expr "of"i case_branch+ case_else? "end"i ";"? -> case_stmt
 case_else:   ELSE stmt+                           -> case_else

--- a/tests/TryExceptOnType.cs
+++ b/tests/TryExceptOnType.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Demo {
+    public partial class TryExceptOnType {
+        public static void DoStuff() {
+            try
+            {
+                Console.WriteLine("A");
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Error");
+            }
+        }
+    }
+}

--- a/tests/TryExceptOnType.pas
+++ b/tests/TryExceptOnType.pas
@@ -1,0 +1,25 @@
+namespace Demo;
+
+interface
+
+uses System;
+
+type
+  TryExceptOnType = public class
+  public
+    class method DoStuff();
+  end;
+
+implementation
+
+class method TryExceptOnType.DoStuff();
+begin
+  try
+    Console.WriteLine('A');
+  except
+    on Exception do
+      Console.WriteLine('Error');
+  end;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -382,6 +382,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_try_except_on_type(self):
+        src = Path('tests/TryExceptOnType.pas').read_text()
+        expected = Path('tests/TryExceptOnType.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_try_except_on_empty(self):
         src = Path('tests/TryExceptOnEmpty.pas').read_text()
         expected = Path('tests/TryExceptOnEmpty.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -954,6 +954,12 @@ class ToCSharp(Transformer):
     def on_handler_empty(self, _on, name, typ, _do):
         return ('on_handler', str(name), typ, '')
 
+    def on_handler_type(self, _on, typ, _do, stmt):
+        return ('on_handler_type', typ, stmt)
+
+    def on_handler_type_empty(self, _on, typ, _do):
+        return ('on_handler_type', typ, '')
+
     def yield_stmt(self, _tok, expr, _semi=None):
         return f"yield return {expr};"
 
@@ -1078,6 +1084,13 @@ class ToCSharp(Transformer):
                     else:
                         catch_body = "{}"
                     res += f"\ncatch ({map_type_ext(str(typ))} {name})\n{catch_body}"
+                elif isinstance(handler, tuple) and handler[0] == 'on_handler_type':
+                    _tag, typ, stmt = handler
+                    if stmt.strip():
+                        catch_body = stmt if stmt.strip().startswith('{') else f"{{\n{indent(stmt)}\n}}"
+                    else:
+                        catch_body = "{}"
+                    res += f"\ncatch ({map_type_ext(str(typ))})\n{catch_body}"
                 else:
                     generic_body.append(handler)
             if generic_body or not except_clause:


### PR DESCRIPTION
## Summary
- allow `except on <type> do` blocks in grammar
- handle new handler form in AST transformer
- add tests for catching by type only

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_try_except_on_type -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d86a96648331b1d1d673723d61fb