### PR TITLE
Add interpolated string support

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -225,6 +225,8 @@ inherited_stmt: "inherited"i (name_term ("(" arg_list? ")" call_postfix*)?)? ";"
            | BINARY_NUMBER                           -> binary_number
            | STRING                                  -> string
            | SQ_STRING                               -> string
+           | INTERP_STRING                           -> string
+           | INTERP_SQ_STRING                        -> string
            | TRUE                                    -> true
            | FALSE                                   -> false
            | NIL                                     -> null
@@ -265,6 +267,8 @@ prop_call: "." name_term GENERIC_ARGS? call_args?     -> prop_call
 index_postfix: ARRAY_RANGE                           -> index_postfix
 literal_string: STRING -> string
               | SQ_STRING -> string
+              | INTERP_STRING -> string
+              | INTERP_SQ_STRING -> string
 
 call_expr:   var_ref "(" arg_list? ")" call_postfix* -> call
            | generic_call_base ("(" arg_list? ")")? call_postfix* -> call
@@ -339,6 +343,7 @@ TRUE:        "true"i
 FALSE:       "false"i
 NIL:         "nil"i
 SQ_STRING:   /'(?:[^'\n]|'')*'/
+INTERP_SQ_STRING: /\$'(?:[^'\n]|'')*'/
 RESULT:      "result"i
 EXIT:        "exit"i
 RAISE:       "raise"i
@@ -389,6 +394,8 @@ CHAR_CODE:   "#" NUMBER ("#" NUMBER)*
 
 HEX_NUMBER: /\$[0-9A-Fa-f]+/
 BINARY_NUMBER: /%[01]+/
+
+INTERP_STRING: /\$"[^"\n]*"/
 
 %import common.CNAME -> BASE_CNAME
 %import common.WS

--- a/tests/InterpolatedStr.cs
+++ b/tests/InterpolatedStr.cs
@@ -1,0 +1,9 @@
+namespace Demo {
+    public partial class InterpolatedStr {
+        public string Quote(string month) {
+            string result;
+            result = $"'{month}'";
+            return result;
+        }
+    }
+}

--- a/tests/InterpolatedStr.pas
+++ b/tests/InterpolatedStr.pas
@@ -1,0 +1,16 @@
+namespace Demo;
+
+type
+  InterpolatedStr = public class
+  public
+    function Quote(month: string): string;
+  end;
+
+implementation
+
+function InterpolatedStr.Quote(month: string): string;
+begin
+  Result := $'''{month}''';
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -87,6 +87,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_interpolated_str(self):
+        src = Path('tests/InterpolatedStr.pas').read_text()
+        expected = Path('tests/InterpolatedStr.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_array_var(self):
         src = Path('tests/ArrayVar.pas').read_text()
         expected = Path('tests/ArrayVar.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -1210,7 +1210,16 @@ class ToCSharp(Transformer):
 
     def string(self, s):
         s = str(s)
-        if s.startswith("'"):
+        if s.startswith("$'"):
+            inner = s[2:-1].replace("''", "'")
+            inner = inner.replace('\\', '\\\\')
+            inner = inner.replace('"', '\\"')
+            return f'$"{inner}"'
+        elif s.startswith('$"'):
+            inner = s[2:-1]
+            inner = inner.replace('\\', '\\\\').replace('"', '\\"')
+            return f'$"{inner}"'
+        elif s.startswith("'"):
             inner = s[1:-1].replace("''", "'")
             inner = inner.replace('\\', '\\\\')
             inner = inner.replace('"', '\\"')


### PR DESCRIPTION
## Summary
- support `$'...'` and `$"..."` style interpolated strings in grammar
- convert interpolated strings to C# style in transformer
- add tests for interpolated strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d90870c083318e33847bbbeb492c