### PR TITLE
Fix lambda parsing

### DIFF
--- a/pas2cs.py
+++ b/pas2cs.py
@@ -47,6 +47,15 @@ def transpile(source: str, manual_translate=None, manual_parse_error=None) -> tu
     source = re.sub(r';[ \t;]*(?=\n|$)', ';', source)
     source = re.sub(r'^\s*;\s*(?=\n)', '', source, flags=re.MULTILINE)
     source = remove_accents_code(source)
+
+    # Insert placeholder type for untyped lambda parameters
+    def _fix_lambda(match):
+        params = match.group(1)
+        if ':' in params:
+            return match.group(0)
+        return f"({params}: Object)"
+
+    source = re.sub(r'\(([^()]*?)\)\s*(?=->|=>)', _fix_lambda, source)
     set_source(source)
     parser = _get_parser()
     try:

--- a/tests/Lambda.cs
+++ b/tests/Lambda.cs
@@ -2,7 +2,8 @@ namespace Demo {
     public partial class LambdaClass {
         public bool Run() {
             var predicate = i => i > 0;
-            return predicate(5);
+            var eq = (a, b) => a == b;
+            return predicate(5) && eq(5, 5);
         }
     }
 }

--- a/tests/Lambda.pas
+++ b/tests/Lambda.pas
@@ -11,7 +11,8 @@ implementation
 method LambdaClass.Run: Boolean;
 begin
   var predicate := (i: Integer) -> i > 0;
-  exit predicate(5);
+  var eq := (a, b) -> a = b;
+  exit predicate(5) and eq(5, 5);
 end;
 
 end.


### PR DESCRIPTION
## Summary
- support lambda parameters without explicit types by preprocessing the source
- extend Lambda test to include untyped parameter case

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_lambda -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d85fe8fc8331b7d68249b184889e