### PR TITLE
Fix semicolon preprocessing after comments

### DIFF
--- a/pas2cs.py
+++ b/pas2cs.py
@@ -38,15 +38,34 @@ def _get_parser() -> Lark:
     return _PARSER
 
 
+def _collapse_semicolon_lines(text: str) -> str:
+    """Move lone semicolons up to the previous line unless it ends with '//'."""
+    lines = text.splitlines()
+    out: list[str] = []
+    for line in lines:
+        if line.strip() == ';' and out:
+            prev = out[-1].rstrip()
+            if '//' in prev or prev.endswith(('}', '*)', '*/')):
+                out.append(line)
+            else:
+                out[-1] = prev + ';'
+                out.append('')
+        else:
+            out.append(line)
+    result = '\n'.join(out)
+    if text.endswith('\n'):
+        result += '\n'
+    return result
+
+
 def transpile(source: str, manual_translate=None, manual_parse_error=None) -> tuple[str, list[str]]:
     source = source.lstrip('\ufeff')
     # Collapse accidental double semicolons. For lines that consist solely of a
     # semicolon we strip the semicolon but keep the line break so error
     # positions still match the original source.
-    source = re.sub(r'(?<!\})\n\s*;\s*(?=\n)', ';\n', source)
+    source = _collapse_semicolon_lines(source)
     source = re.sub(r'\}\s*;', '}', source)
     source = re.sub(r';[ \t;]*(?=\n|$)', ';', source)
-    source = re.sub(r'^\s*;\s*(?=\n)', '', source, flags=re.MULTILINE)
     source = remove_accents_code(source)
 
     # Insert placeholder type for untyped lambda parameters

--- a/tests/MultiVars.cs
+++ b/tests/MultiVars.cs
@@ -7,5 +7,11 @@ namespace Demo {
             dt_aux = ano_aux + mes_aux;
             System.Console.WriteLine(dt_aux);
         }
+        public static void SplitDecl() {
+            string s105_deposito_FGTS;
+            string s106_base_calc_FGTS;
+            string s107_total_proventos;
+            System.Console.WriteLine(s107_total_proventos);
+        }
     }
 }

--- a/tests/MultiVars.pas
+++ b/tests/MultiVars.pas
@@ -4,6 +4,7 @@ type
   MultiVars = public class
   public
     class method Demo();
+    class method SplitDecl();
   end;
 
 implementation
@@ -16,5 +17,16 @@ begin
   mes_aux := '12';
   dt_aux := ano_aux + mes_aux;
   System.Console.WriteLine(dt_aux);
+end;
+
+class method MultiVars.SplitDecl();
+var  s105_deposito_FGTS  : String
+;
+     s106_base_calc_FGTS   : String // comment on same line
+;
+     s107_total_proventos: String
+;
+begin
+  System.Console.WriteLine(s107_total_proventos);
 end;
 


### PR DESCRIPTION
## Summary
- avoid removing standalone semicolons when the previous line ends in `//` comment
- add a regression test for this scenario in MultiVars

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_multi_vars -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862dcf525908331a29afbbc10657f48