### PR TITLE
Fix parser for `as` cast property assignment

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -198,7 +198,7 @@ case_label: signed_number DOTDOT signed_number        -> label_range
 call_stmt:   var_ref ("(" arg_list? ")")? call_postfix* ";"?   -> call_stmt
            | generic_call_base ("(" arg_list? ")")? call_postfix* ";"? -> call_stmt
            | new_expr "." name_term ("(" arg_list? ")")? call_postfix* ";"?    -> call_stmt
-           | "(" expr ")" "." name_term ("(" arg_list? ")")? call_postfix* ";"? -> call_stmt
+           | "(" expr ")" prop_call call_postfix* ";"? -> call_stmt
 inherited_stmt: "inherited"i (name_term ("(" arg_list? ")" call_postfix*)?)? ";"? -> inherited
 
 ?expr:       lambda_expr
@@ -275,7 +275,7 @@ call_expr:   var_ref "(" arg_list? ")" call_postfix* -> call
            | generic_call_base ("(" arg_list? ")")? call_postfix* -> call
            | new_expr "." name_term GENERIC_ARGS? call_args? call_postfix* -> call
            | array_of_expr prop_call call_postfix* -> call
-           | "(" expr ")" "." name_term GENERIC_ARGS? call_args? call_postfix* -> call
+           | "(" expr ")" prop_call call_postfix* -> call
            | literal_string "." name_term GENERIC_ARGS? call_args? call_postfix* -> call
            | "inherited"i name_term GENERIC_ARGS? call_args? call_postfix* -> inherited_call_expr
            | typeof_expr call_postfix+                     -> call
@@ -284,7 +284,7 @@ call_lhs:   var_ref "(" arg_list? ")" call_postfix+                 -> call
            | generic_call_base ("(" arg_list? ")")? call_postfix+    -> call
            | new_expr "." name_term GENERIC_ARGS? call_args? call_postfix+ -> call
            | array_of_expr prop_call call_postfix+ -> call
-           | "(" expr ")" "." name_term GENERIC_ARGS? call_args? call_postfix+ -> call
+           | "(" expr ")" prop_call call_postfix* -> call
            | literal_string "." name_term GENERIC_ARGS? call_args? call_postfix+ -> call
            | typeof_expr call_postfix+                                 -> call
 arg_list:    arg ("," arg)*

--- a/tests/TypeCasting.cs
+++ b/tests/TypeCasting.cs
@@ -13,6 +13,9 @@ namespace Demo {
         public void Update(object adapter, object ds, string name) {
             (adapter as DB2DataAdapter).Update(ds, name);
         }
+        public void SetText(object ctrl, string valor) {
+            (ctrl as TextBox).Text = valor;
+        }
     }
     
     public partial class IsExample {

--- a/tests/TypeCasting.pas
+++ b/tests/TypeCasting.pas
@@ -9,6 +9,7 @@ type
   AsCastCall = public class
   public
     method Update(adapter: Object; ds: Object; name: String);
+    method SetText(ctrl: Object; valor: String);
   end;
 
   IsExample = class
@@ -29,6 +30,11 @@ end;
 method AsCastCall.Update(adapter: Object; ds: Object; name: String);
 begin
   (adapter as DB2DataAdapter).Update(ds, name);
+end;
+
+method AsCastCall.SetText(ctrl: Object; valor: String);
+begin
+  (ctrl as TextBox).Text := valor;
 end;
 
 class method IsExample.Check(o: Object);


### PR DESCRIPTION
## Summary
- update grammar to allow property access after an `as` cast
- add test covering `(ctrl as TextBox).Text := valor;`

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_type_casting -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862de73ecf883318d0e675e83b3f961