### PR TITLE
Allow access modifiers after '=' in aliases

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -41,7 +41,7 @@ class_forward: CNAME generic_params? "=" ("public"i)? "static"? "partial"? ("sea
 record_def:  CNAME generic_params? "=" ("public"i)? "packed"i? "record"i ("(" type_name ")")? class_signature "end"i ";" -> record_def
 interface_def: CNAME generic_params? "=" ("public"i)? "interface"i ("(" type_name ("," type_name)* ")")? class_signature "end"i ";" -> interface_def
 enum_def:    CNAME "=" ("public"i)? ("enum"i | "flags"i)? "(" enum_items ")" ("of" type_name)? ";" -> enum_def
-alias_def:   access_modifier? CNAME generic_params? "=" type_spec ";"     -> alias_def
+alias_def:   access_modifier? CNAME generic_params? "=" access_modifier? type_spec ";"     -> alias_def
 enum_items:  enum_item ("," enum_item)* -> enum_items
 enum_item:   CNAME ("=" NUMBER)?                               -> enum_item
 

--- a/tests/AliasDef.cs
+++ b/tests/AliasDef.cs
@@ -1,3 +1,4 @@
+using ArrayInt = int[];
 using MimeMappingType = System.Type;
 
 namespace Demo {

--- a/tests/AliasDef.pas
+++ b/tests/AliasDef.pas
@@ -1,6 +1,8 @@
 namespace Demo;
 
 type
+  ArrayInt = public array of Integer;
+
   MimeMappingType = &Type;
 
   AliasHolder = public class

--- a/transformer.py
+++ b/transformer.py
@@ -383,6 +383,12 @@ class ToCSharp(Transformer):
         return ""
 
     def alias_def(self, *parts):
+        if len(parts) == 1 and isinstance(parts[0], list):
+            parts = tuple(parts[0])
+
+        # remove placeholder strings from optional access modifiers
+        parts = [p for p in parts if p != ""]
+
         if len(parts) == 4:
             _acc, cname, generics, typ = parts
         elif len(parts) == 3:


### PR DESCRIPTION
## Summary
- support optional access modifier after `=` in alias definitions
- handle flattened alias nodes in transformer
- update alias test with `public array` case

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_alias_def -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862dee651e88331be0af0c568f07a3f