### PR TITLE
Fix parsing of variables named 'enum'

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -80,7 +80,8 @@ return_block: ":" type_spec                           -> rettype
 param_list:  param (";" param)*
 param:       (VAR|OUT|CONST)? name_list ":" type_spec ((OP_REL["="] | ":=") expr)? -> param
             | (VAR|OUT|CONST) name_list ((OP_REL["="] | ":=") expr)? -> param_untyped
-name_list:   CNAME ("," CNAME)* -> names
+identifier: CNAME | ENUM
+name_list:   identifier ("," identifier)* -> names
 
 type_spec: type_name "?"?                              -> type_spec
 

--- a/tests/PasKeywordVar.cs
+++ b/tests/PasKeywordVar.cs
@@ -1,0 +1,8 @@
+namespace Demo {
+    public partial class PasKeywordVar {
+        public void Demo() {
+            int @enum;
+            @enum = 1;
+        }
+    }
+}

--- a/tests/PasKeywordVar.pas
+++ b/tests/PasKeywordVar.pas
@@ -1,0 +1,18 @@
+namespace Demo;
+
+type
+  PasKeywordVar = public class
+  public
+    method Demo;
+  end;
+
+implementation
+
+method PasKeywordVar.Demo;
+var
+  enum: Integer;
+begin
+  enum := 1;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -597,6 +597,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_pas_keyword_var(self):
+        src = Path('tests/PasKeywordVar.pas').read_text()
+        expected = Path('tests/PasKeywordVar.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_sealed_class(self):
         src = Path('tests/SealedClass.pas').read_text()
         expected = Path('tests/SealedClass.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -484,6 +484,9 @@ class ToCSharp(Transformer):
         generics = rest[0].value if rest else ""
         return str(name) + generics
 
+    def identifier(self, tok):
+        return str(tok)
+
     def params(self, items=None):
         return items or []
 


### PR DESCRIPTION
## Summary
- allow `enum` as an identifier in declarations
- map `identifier` rule in transformer
- add regression test for Pascal keyword variable names

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_pas_keyword_var -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ec1b0c9083318d523a76b15e7161