### PR TITLE
Handle Pascal keywords used as variable names

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -80,7 +80,8 @@ return_block: ":" type_spec                           -> rettype
 param_list:  param (";" param)*
 param:       (VAR|OUT|CONST)? name_list ":" type_spec ((OP_REL["="] | ":=") expr)? -> param
             | (VAR|OUT|CONST) name_list ((OP_REL["="] | ":=") expr)? -> param_untyped
-name_list:   CNAME ("," CNAME)* -> names
+
+name_list:   (CNAME | ENUM | INTERFACE) ("," (CNAME | ENUM | INTERFACE))* -> names
 
 type_spec: type_name "?"?                              -> type_spec
 

--- a/tests/PasKeywordVar.cs
+++ b/tests/PasKeywordVar.cs
@@ -1,0 +1,10 @@
+namespace Demo {
+    public partial class PasKeywordVar {
+        public void Demo() {
+            int @enum;
+            int @interface;
+            @enum = 1;
+            @interface = @enum;
+        }
+    }
+}

--- a/tests/PasKeywordVar.pas
+++ b/tests/PasKeywordVar.pas
@@ -1,0 +1,20 @@
+namespace Demo;
+
+type
+  PasKeywordVar = public class
+  public
+    method Demo;
+  end;
+
+implementation
+
+method PasKeywordVar.Demo;
+var
+  enum: Integer;
+  interface: Integer;
+begin
+  enum := 1;
+  interface := enum;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -597,6 +597,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_pas_keyword_var(self):
+        src = Path('tests/PasKeywordVar.pas').read_text()
+        expected = Path('tests/PasKeywordVar.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_sealed_class(self):
         src = Path('tests/SealedClass.pas').read_text()
         expected = Path('tests/SealedClass.cs').read_text().strip()

--- a/utils.py
+++ b/utils.py
@@ -173,6 +173,15 @@ def fix_keyword(tok):
         _LAST_POS = tok.end_pos
         return tok
 
+    if tok.value.lower() in ('enum', 'interface'):
+        pos = tok.end_pos
+        while pos < len(_SRC_TEXT) and _SRC_TEXT[pos].isspace():
+            pos += 1
+        if pos < len(_SRC_TEXT) and _SRC_TEXT[pos] == ':':
+            tok.type = 'CNAME'
+            _LAST_POS = tok.end_pos
+            return tok
+
     token_type = KEYWORD_MAP.get(v)
     if token_type:
         tok.type = token_type


### PR DESCRIPTION
## Summary
- allow ENUM and INTERFACE tokens in variable/parameter name lists
- treat `enum` and `interface` identifiers followed by ':' as normal names
- test Pascal keywords used as variables

## Testing
- `pytest -q tests/test_transpile.py::TranspileTests::test_pas_keyword_var tests/test_transpile.py::TranspileTests::test_alias_def`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862ec1b0c9083318d523a76b15e7161