### PR TITLE
Handle empty 'on...do' without semicolon

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -179,9 +179,9 @@ try_stmt:    TRY stmt* except_clause? finally_clause? "end"i ";"? -> try_stmt
 except_clause: EXCEPT ";"? (on_handler | on_handler_type | stmt)*                -> except_clause
 finally_clause: FINALLY stmt*
 on_handler: ON CNAME ":" type_name DO stmt -> on_handler
-          | ON CNAME ":" type_name DO ";" -> on_handler_empty
+          | ON CNAME ":" type_name DO ";"? -> on_handler_empty
 on_handler_type: ON type_name DO stmt -> on_handler_type
-               | ON type_name DO ";" -> on_handler_type_empty
+               | ON type_name DO ";"? -> on_handler_type_empty
 
 case_stmt:   "case"i expr "of"i case_branch+ case_else? "end"i ";"? -> case_stmt
 case_else:   ELSE stmt+                           -> case_else

--- a/tests/TryExceptOnEmpty.cs
+++ b/tests/TryExceptOnEmpty.cs
@@ -10,5 +10,14 @@ namespace Demo {
             catch (Exception E)
             {}
         }
+        public static void DoNothingNoSemi() {
+            try
+            {
+                Console.WriteLine("B");
+            }
+            catch (Exception E)
+            {}
+        }
     }
 }
+

--- a/tests/TryExceptOnEmpty.pas
+++ b/tests/TryExceptOnEmpty.pas
@@ -8,6 +8,7 @@ type
   TryExceptOnEmpty = public class
   public
     class method DoStuff();
+    class method DoNothingNoSemi();
   end;
 
 implementation
@@ -21,4 +22,14 @@ begin
   end;
 end;
 
+class method TryExceptOnEmpty.DoNothingNoSemi();
+begin
+  try
+    Console.WriteLine('B');
+  except
+    on E: Exception do
+  end;
+end;
+
 end.
+

--- a/transformer.py
+++ b/transformer.py
@@ -954,13 +954,13 @@ class ToCSharp(Transformer):
     def on_handler(self, _on, name, typ, _do, stmt):
         return ('on_handler', str(name), typ, stmt)
 
-    def on_handler_empty(self, _on, name, typ, _do):
+    def on_handler_empty(self, _on, name, typ, _do, _semi=None):
         return ('on_handler', str(name), typ, '')
 
     def on_handler_type(self, _on, typ, _do, stmt):
         return ('on_handler_type', typ, stmt)
 
-    def on_handler_type_empty(self, _on, typ, _do):
+    def on_handler_type_empty(self, _on, typ, _do, _semi=None):
         return ('on_handler_type', typ, '')
 
     def yield_stmt(self, _tok, expr, _semi=None):


### PR DESCRIPTION
## Summary
- support missing semicolon after `on ... do` in try/except handlers
- update transformer to accept optional semicolon tokens
- add a test case for `on ... do` with no statement or semicolon

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_try_except_on_empty -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f06179c08331a5fb437090451fcc