### PR TITLE
Handle dynamic colon calls

### DIFF
--- a/pas2cs.py
+++ b/pas2cs.py
@@ -68,6 +68,11 @@ def transpile(source: str, manual_translate=None, manual_parse_error=None) -> tu
     source = re.sub(r';[ \t;]*(?=\n|$)', ';', source)
     source = remove_accents_code(source)
 
+    # Convert Oxygene dynamic calls using ':' to standard '.' notation
+    source = re.sub(r'(?<=\])\s*:(?=\s*[A-Za-z_]\w*\s*\()', '.', source)
+    source = re.sub(r'(?<=\))\s*:(?=\s*[A-Za-z_]\w*\s*\()', '.', source)
+    source = re.sub(r'(?<!assembly)(?<=\w)\s*:(?=\s*[A-Za-z_]\w*\s*\()', '.', source, flags=re.IGNORECASE)
+
     # Insert placeholder type for untyped lambda parameters
     def _fix_lambda(match):
         params = match.group(1)

--- a/tests/DynamicCall.cs
+++ b/tests/DynamicCall.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class DynamicCall {
+        public void Test(object o) {
+            var texto = o.ToString();
+        }
+    }
+}

--- a/tests/DynamicCall.pas
+++ b/tests/DynamicCall.pas
@@ -1,0 +1,16 @@
+namespace Demo;
+
+type
+  DynamicCall = public class
+  public
+    method Test(o: Object);
+  end;
+
+implementation
+
+method DynamicCall.Test(o: Object);
+begin
+  var texto := o:ToString();
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -836,6 +836,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_dynamic_call(self):
+        src = Path('tests/DynamicCall.pas').read_text()
+        expected = Path('tests/DynamicCall.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_safe_print_cp1252(self):
         import io, sys
         from utils import safe_print


### PR DESCRIPTION
## Summary
- preprocess source to transform Oxygene dynamic calls that use `:` into normal `.` invocation
- cover dynamic call case with tests

## Testing
- `pytest -q`
- `pytest -q tests/test_transpile.py::TranspileTests::test_dynamic_call -q`


------
https://chatgpt.com/codex/tasks/task_e_6862efbd65b88331aeebe9e35b4e75ff