### PR TITLE
Add test for dataset row count visibility

### DIFF
--- a/tests/ExampleIssue.cs
+++ b/tests/ExampleIssue.cs
@@ -1,0 +1,14 @@
+using System.Data;
+
+namespace Demo {
+    public partial class Controller {
+        public static void Check(DataSet ds, object r) {
+            if (getControlador.getDocDespesa.sitDoc == "AGUARD APROV DOC") {
+                u = TUSUArio(session["usuario"]);
+                ds = u.buscarUsuarioPrograma(u.idUsuario, TPrograma.codProgramaAprovacaoDocumento);
+                r.Visible = ds.Tables[0].Rows.Count > 0;
+                if (TSGUUtils.testarStrNulo(getControlador.getDocDespesa.chaveAcesso) == "") detDoc.exibeLinkReceita();
+            }
+        }
+    }
+}

--- a/tests/ExampleIssue.pas
+++ b/tests/ExampleIssue.pas
@@ -1,0 +1,27 @@
+namespace Demo;
+
+interface
+
+uses System.Data;
+
+type
+  Controller = public class
+  public
+    class method Check(ds: DataSet; r: Object);
+  end;
+
+implementation
+
+class method Controller.Check(ds: DataSet; r: Object);
+begin
+  if (getControlador.getDocDespesa.sitDoc = 'AGUARD APROV DOC') then
+  begin
+    u := TUSUArio(session['usuario']);
+    ds := u.buscarUsuarioPrograma(u.idUsuario, TPrograma.codProgramaAprovacaoDocumento);
+    r.Visible := (ds.Tables[0].Rows.Count > 0);
+    if (TSGUUtils.testarStrNulo(getControlador.getDocDespesa.chaveAcesso)='') then
+      detDoc.exibeLinkReceita;
+  end;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -836,6 +836,15 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_example_issue(self):
+        src = Path("tests/ExampleIssue.pas").read_text()
+        expected = Path("tests/ExampleIssue.cs").read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+
+
     def test_safe_print_cp1252(self):
         import io, sys
         from utils import safe_print


### PR DESCRIPTION
## Summary
- add ExampleIssue fixture showing dataset row count comparison
- ensure transpiler handles property assignment with dataset row count

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_example_issue -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f1569d0c83318e9014d073ac441d