### PR TITLE
Fix namespace semicolon handling

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -21,10 +21,10 @@ name_part: CNAME
          | RESULT
 
 dotted_name: name_part ("." name_part)* -> dotted
-namespace:   "namespace" dotted_name ";"                       -> namespace
-unit_decl:   "unit" dotted_name ";"                             -> namespace
-program_decl: "program"i dotted_name ";"              -> namespace
-library_decl: "library" dotted_name ";"                          -> namespace
+namespace:   "namespace" dotted_name ";"?                      -> namespace
+unit_decl:   "unit" dotted_name ";"?                            -> namespace
+program_decl: "program"i dotted_name ";"?             -> namespace
+library_decl: "library" dotted_name ";"?                         -> namespace
 initialization_section: "initialization" stmt* finalization_section?
 finalization_section: "finalization" stmt*
 

--- a/pas2cs.py
+++ b/pas2cs.py
@@ -43,6 +43,10 @@ def transpile(source: str, manual_translate=None, manual_parse_error=None) -> tu
     # Collapse accidental double semicolons. For lines that consist solely of a
     # semicolon we strip the semicolon but keep the line break so error
     # positions still match the original source.
+    # Move semicolons on their own line up to the previous line.
+    # When the preceding line ends with a comment, place the semicolon before
+    # the comment so it's not swallowed by the lexer.
+    source = re.sub(r'(?m)(.*?)(//[^\n]*)\n\s*;\s*(?=\n)', r'\1; \2\n', source)
     source = re.sub(r'(?<!\})\n\s*;\s*(?=\n)', ';\n', source)
     source = re.sub(r'\}\s*;', '}', source)
     source = re.sub(r';[ \t;]*(?=\n|$)', ';', source)

--- a/tests/SemicolonCases.pas
+++ b/tests/SemicolonCases.pas
@@ -1,4 +1,4 @@
-namespace Demo;
+namespace Demo
 
 type
   Foo = public class


### PR DESCRIPTION
## Summary
- allow optional semicolons after `namespace`, `unit`, `program`, and `library`
- preserve semicolons when comments appear before them
- test parsing a namespace without a trailing semicolon

## Testing
- `pytest -k test_multi_vars -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862f26767c8833188daa9827e7939b7