### PR TITLE
Support property directives like `reintroduce`

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -51,7 +51,7 @@ member_decl: attributes? method_decl_rule
            | attributes? access_modifier? class_modifier attributes? name_list ":" type_spec (":=" expr)? ";"      -> field_decl
            | access_modifier? name_list ":" type_spec (":=" expr)? ";"      -> field_decl
 
-           | attributes? access_modifier? "class"? "property"i property_sig ";"      -> property_decl
+           | attributes? access_modifier? "class"? "property"i property_sig ";" (method_attr ";")*      -> property_decl
            | attributes? access_modifier? "event"i CNAME ":" type_spec event_end  -> event_decl
            | attributes? access_modifier? "class"? "const"i const_decl+            -> const_block
            | access_modifier                                   -> section

--- a/tests/ReintroduceProp.cs
+++ b/tests/ReintroduceProp.cs
@@ -1,0 +1,5 @@
+namespace Demo {
+    public partial class Reintro {
+        public string Url { get => get_Url(); set => set_Url(value); }
+    }
+}

--- a/tests/ReintroduceProp.pas
+++ b/tests/ReintroduceProp.pas
@@ -1,0 +1,7 @@
+namespace Demo;
+
+type
+  Reintro = public class
+  public
+    property Url: System.String read get_Url write set_Url; reintroduce;
+  end;

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -184,6 +184,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_property_reintroduce(self):
+        src = Path('tests/ReintroduceProp.pas').read_text()
+        expected = Path('tests/ReintroduceProp.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_no_implementation(self):
         src = Path('tests/NoImpl.pas').read_text()
         expected = Path('tests/NoImpl.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -711,7 +711,13 @@ class ToCSharp(Transformer):
         return None
 
     def property_decl(self, *parts):
-        sig = parts[-1]
+        sig = None
+        for p in parts:
+            if isinstance(p, tuple) and len(p) == 4:
+                sig = p
+                break
+        if sig is None:
+            return ""
         name, typ, getter, setter = sig
         parts_cs = " ".join(p for p in [getter, setter] if p)
         impl = f"public {typ} {name} {{ {parts_cs} }}"


### PR DESCRIPTION
## Summary
- extend `property_decl` rule in `grammar.py` to allow directives after the read/write section
- adjust `property_decl` transformer to ignore optional directives
- add regression test for property with `reintroduce`

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_property_reintroduce -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6862f2a5b03c833190a939b293e95269