### PR TITLE
Support empty while loop statement

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -177,7 +177,7 @@ else_clause: ELSE stmt                           -> else_clause
 for_stmt:    "for"i CNAME (":" type_spec)? ":=" expr (TO | DOWNTO) expr (STEP expr)? ("do"i)? stmt  -> for_stmt
            | "for"i "each"i? CNAME (":" type_spec)? IN expr (INDEX CNAME)? ("do"i)? stmt      -> for_each_stmt
 loop_stmt:   LOOP stmt                                       -> loop_stmt
-while_stmt:  "while"i expr "do"i stmt                    -> while_stmt
+while_stmt:  "while"i expr "do"i (stmt | empty_stmt)      -> while_stmt
 
 try_stmt:    TRY stmt* except_clause? finally_clause? "end"i ";"? -> try_stmt
 except_clause: EXCEPT ";"? (on_handler | on_handler_type | stmt)*                -> except_clause

--- a/tests/Loops.cs
+++ b/tests/Loops.cs
@@ -66,6 +66,13 @@ namespace Demo {
         }
     }
     
+    public partial class WhileEmptyDemo {
+        public static void DoNothing() {
+            int i = 0;
+            while (i < 3);
+        }
+    }
+    
     public partial class TypedForEach {
         public static int Sum(int[] arr) {
             int result;

--- a/tests/Loops.pas
+++ b/tests/Loops.pas
@@ -36,6 +36,11 @@ type
     class method Test(arr: Array of Integer);
   end;
 
+  WhileEmptyDemo = public class
+  public
+    class method DoNothing();
+  end;
+
   TypedForEach = public class
   public
     class method Sum(arr: array of Integer): Integer;
@@ -119,6 +124,13 @@ var
 begin
   while (i <= 2) do
     i := i + arr[0];
+end;
+
+class method WhileEmptyDemo.DoNothing();
+var
+  i: Integer := 0;
+begin
+  while i < 3 do;
 end;
 
 class method TypedForEach.Sum(arr: array of Integer): Integer;

--- a/transformer.py
+++ b/transformer.py
@@ -1096,6 +1096,9 @@ class ToCSharp(Transformer):
         return f"while (true) {body}"
 
     def while_stmt(self, cond, body):
+        body_str = str(body).strip()
+        if not body_str:
+            return f"while ({cond});"
         return f"while ({cond}) {body}"
 
     def try_stmt(self, *parts):


### PR DESCRIPTION
## Summary
- allow `while` statements with empty bodies in the grammar
- emit `while (cond);` when the loop body is empty
- add empty-while example to Loops test cases

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_loops -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862fb5c09dc83318a454664d0c714b7