### PR TITLE
Support inherited property assignments via grammar

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -17,6 +17,8 @@ name_part: CNAME
          | ENUM
          | EVENT
          | OPERATOR
+         | CONSTRUCTOR
+         | DESTRUCTOR
          | TUPLE
          | RESULT
 
@@ -154,7 +156,7 @@ block:       "begin" ";"? stmt* "end"i ";"?
            | block
            
 
-assign_stmt: (var_ref | call_lhs) ":=" expr ";"?                     -> assign
+assign_stmt: (inherited_var | var_ref | call_lhs) ":=" expr ";"? -> assign
 op_assign_stmt: (var_ref | call_lhs) ADD_ASSIGN expr ";"?              -> op_assign
               | (var_ref | call_lhs) SUB_ASSIGN expr ";"?              -> op_assign
 return_stmt: RESULT ":=" expr ";"?                      -> result_ret
@@ -203,7 +205,7 @@ call_stmt:   var_ref ("(" arg_list? ")")? call_postfix* ";"?   -> call_stmt
            | generic_call_base ("(" arg_list? ")")? call_postfix* ";"? -> call_stmt
            | new_expr "." name_term ("(" arg_list? ")")? call_postfix* ";"?    -> call_stmt
            | "(" expr ")" prop_call call_postfix* ";"? -> call_stmt
-inherited_stmt: "inherited"i (name_term ("(" arg_list? ")" call_postfix*)?)? ";"? -> inherited
+inherited_stmt: INHERITED (name_term ("(" arg_list? ")" call_postfix*)?)? ";"? -> inherited
 
 ?expr:       lambda_expr
            | NOT expr                                -> not_expr
@@ -281,7 +283,7 @@ call_expr:   var_ref "(" arg_list? ")" call_postfix* -> call
            | array_of_expr prop_call call_postfix* -> call
            | "(" expr ")" prop_call call_postfix* -> call
            | literal_string "." name_term GENERIC_ARGS? call_args? call_postfix* -> call
-           | "inherited"i name_term GENERIC_ARGS? call_args? call_postfix* -> inherited_call_expr
+           | INHERITED name_term GENERIC_ARGS? call_args? call_postfix* -> inherited_call_expr
            | typeof_expr call_postfix+                     -> call
 
 call_lhs:   var_ref "(" arg_list? ")" call_postfix+                 -> call
@@ -299,6 +301,7 @@ arg:         OUT expr                                -> out_arg
            | expr
 
 new_stmt:    new_expr ";"?
+inherited_var: INHERITED name_base (ARRAY_RANGE | "." name_term)* -> inherited_var
 var_ref:     name_base (ARRAY_RANGE | "." name_term)* -> var
            | "(" expr ")" ARRAY_RANGE -> paren_index
 
@@ -325,6 +328,7 @@ PROCEDURE:   "procedure"i
 FUNCTION:    "function"i
 CONSTRUCTOR: "constructor"i
 DESTRUCTOR:  "destructor"i
+INHERITED:   "inherited"i
 VAR:         "var"i
 CLASSVAR.2:  /class\s+var/i
 OUT:         "out"i

--- a/tests/PropertyAssign.cs
+++ b/tests/PropertyAssign.cs
@@ -9,6 +9,20 @@ namespace Demo {
         }
     }
     
+    public partial class BaseService {
+        // TODO: field UseDefaultCredentials: bool -> declare a field
+        public bool UseDefaultCredentials;
+        // TODO: field Url: string -> declare a field
+        public string Url;
+    }
+    
+    public partial class ServiceLogin : BaseService {
+        public void SetUrl(string value) {
+            base.UseDefaultCredentials = false;
+            base.Url = value;
+        }
+    }
+    
     public partial struct RecordData {
         // TODO: field numeroRegistros: int -> declare a field
         public int numeroRegistros;

--- a/tests/PropertyAssign.pas
+++ b/tests/PropertyAssign.pas
@@ -6,6 +6,17 @@ type
     method Example(perm: RecordData);
   end;
 
+  BaseService = public class
+  public
+    UseDefaultCredentials: Boolean;
+    Url: String;
+  end;
+
+  ServiceLogin = public class(BaseService)
+  public
+    method SetUrl(value: String);
+  end;
+
   RecordData = public record
     numeroRegistros: Integer;
   end;
@@ -19,6 +30,12 @@ begin
   gMeta.Visible := perm.numeroRegistros > 0;
   CustomValidator(source).ErrorMessage := 'Selecione um funcionario';
   CheckBox(e.Item.Cells[3].controls[0]).checked := string(ds.Tables[0].DefaultView.Item[e.Item.ItemIndex]['IND_TRAMITACAO']) = 'S';
+end;
+
+method ServiceLogin.SetUrl(value: String);
+begin
+  inherited UseDefaultCredentials := false;
+  inherited Url := value;
 end;
 
 end.

--- a/transformer.py
+++ b/transformer.py
@@ -1310,6 +1310,9 @@ class ToCSharp(Transformer):
                 out.append('.' + self._safe_name(p))
         return ''.join(out)
 
+    def inherited_var(self, _tok, base, *parts):
+        return 'base.' + self.var(base, *parts)
+
     def prop_call(self, name, generics=None, args=None):
         nm = str(name)
         if isinstance(generics, list) and args is None:
@@ -1414,7 +1417,7 @@ class ToCSharp(Transformer):
     def new_stmt(self, expr):
         return expr + ";"
 
-    def inherited(self, name=None, args=None):
+    def inherited(self, _tok=None, name=None, args=None):
         if name is None:
             if self.curr_method:
                 base = self.class_defs.get(self.curr_impl_class, ("", "", [], set()))[1]
@@ -1437,7 +1440,7 @@ class ToCSharp(Transformer):
             return f"base.{name}({arglist});"
         return ""
 
-    def inherited_call_expr(self, name, args=None):
+    def inherited_call_expr(self, _tok, name, args=None):
         arglist = "" if args is None else ", ".join(args)
         if str(name).lower() == "constructor":
             base_name = self.curr_method or "constructor"

--- a/utils.py
+++ b/utils.py
@@ -141,6 +141,7 @@ KEYWORD_MAP = {
     "program": "PROGRAM",
     "initialization": "INITIALIZATION",
     "finalization": "FINALIZATION",
+    "inherited": "INHERITED",
 }
 
 def set_source(text: str) -> None:


### PR DESCRIPTION
## Summary
- extend `name_part` to include CONSTRUCTOR and DESTRUCTOR
- add `inherited_var` rule and update `assign_stmt`
- expose `INHERITED` token in keyword map
- adjust `inherited` and `inherited_call_expr` visitors
- drop preprocessing of inherited references

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862fc5be7188331afbef37125fd59d2