### PR TITLE
Handle region comments in class bodies

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -51,9 +51,10 @@ enum_item:   CNAME ("=" NUMBER)?                               -> enum_item
 
 class_signature: member_decl* -> class_sign
 member_decl: attributes? method_decl_rule
-           | attributes? access_modifier? (CLASSVAR | VAR) attributes? name_list ":" type_spec (":=" expr)? ";"      -> field_decl
-           | attributes? access_modifier? class_modifier attributes? name_list ":" type_spec (":=" expr)? ";"      -> field_decl
-           | access_modifier? name_list ":" type_spec (":=" expr)? ";"      -> field_decl
+           | attributes? access_modifier? (CLASSVAR | VAR) attributes? name_list ":" type_spec (":=" expr)? ";" comment?      -> field_decl
+           | attributes? access_modifier? class_modifier attributes? name_list ":" type_spec (":=" expr)? ";" comment?      -> field_decl
+           | access_modifier? name_list ":" type_spec (":=" expr)? ";" comment?      -> field_decl
+           | comment_stmt
 
            | attributes? access_modifier? "class"? "property"i property_sig ";" (method_attr ";")*      -> property_decl
            | attributes? access_modifier? "event"i CNAME ":" type_spec event_end  -> event_decl
@@ -124,6 +125,7 @@ const_block: "const" const_decl+
 pre_class_decl: const_block
               | var_section
               | method_decl_rule
+              | comment_stmt
 
 class_impl:  attributes? class_modifier? method_kind method_impl
 method_impl: attributes? impl_head ";" method_decls? block               -> m_impl
@@ -153,6 +155,7 @@ block:       "begin" ";"? stmt* "end"i ";"?
            | yield_stmt
            | call_stmt
            | new_stmt
+           | comment_stmt
            | block
            
 
@@ -173,6 +176,7 @@ locking_stmt: LOCKING expr DO stmt                      -> locking_stmt
 with_stmt: WITH expr DO stmt                           -> with_stmt
 yield_stmt: YIELD expr ";"?                           -> yield_stmt
 empty_stmt: ";"                                      -> empty
+comment_stmt: comment                                -> comment_stmt
 if_stmt:     "if"i expr THEN (stmt | empty_stmt)? else_clause?        -> if_stmt
 else_clause: ELSE stmt                           -> else_clause
            | ELSE                                -> else_clause_empty
@@ -306,8 +310,8 @@ var_ref:     name_base (ARRAY_RANGE | "." name_term)* -> var
            | "(" expr ")" ARRAY_RANGE -> paren_index
 
 var_section: ("var"i | "threadvar"i) (var_decl | var_decl_infer)+
-var_decl:    name_list ":" type_spec (":=" expr)? ";"       -> var_decl
-var_decl_infer: name_list ":=" expr ";"                 -> var_decl_infer
+var_decl:    name_list ":" type_spec (":=" expr)? ";" comment?       -> var_decl
+var_decl_infer: name_list ":=" expr ";" comment?                 -> var_decl_infer
 
 LT:           "<"
 GT:           ">"
@@ -419,9 +423,10 @@ LINE_COMMENT.4: /\/\/[^\n]*/
 COMMENT_PAREN: /\(\*[\s\S]*?\*\)/
 COMMENT_STAR.4: /\/\*[\s\S]*?\*\//
 %ignore WS
-%ignore COMMENT_BRACE
-%ignore LINE_COMMENT
-%ignore COMMENT_PAREN
-%ignore COMMENT_STAR
 %ignore /\}/
+
+comment: COMMENT_BRACE
+       | COMMENT_PAREN
+       | COMMENT_STAR
+       | LINE_COMMENT
 """

--- a/tests/Comments.cs
+++ b/tests/Comments.cs
@@ -3,23 +3,33 @@ using System;
 namespace Demo {
     public partial class Commented {
         public void SayHello() {
+            /* region Hello */
             System.Console.WriteLine("Hello");
+            /* endregion */
         }
     }
     
     public partial class Foo {
+        /* $REGION 'extra' */
+        /* $ENDREGION */
         public int ValueParen() {
             int result;
+            /* comment with *** inside
+                 multiple lines */
             result = 123;
             return result;
         }
         public int ValueBrace() {
             int result;
+            /* comment
+                multiple lines */
             result = 123;
             return result;
         }
         public int ValueCStyle() {
             int result;
+            /* comment
+                 multiple lines */
             result = 123;
             return result;
         }

--- a/tests/Comments.pas
+++ b/tests/Comments.pas
@@ -13,7 +13,9 @@ type
   Foo = class
   public
     method ValueParen: Integer;
+    {$REGION 'extra'}
     method ValueBrace: Integer;
+    {$ENDREGION}
     method ValueCStyle: Integer;
   end;
 

--- a/tests/IfStatements.cs
+++ b/tests/IfStatements.cs
@@ -24,6 +24,7 @@ namespace Demo {
         public static void Demo(bool flag) {
             if (flag) {
                 if (flag) {}
+                // no-op
                 {
                     System.Console.WriteLine("Hello");
                 }
@@ -33,7 +34,7 @@ namespace Demo {
     
     public partial class IfElseEmptyExample {
         public static void Check(bool flag) {
-            if (flag) Console.WriteLine("yes"); else {}
+            if (flag) Console.WriteLine("yes"); // nothing
         }
     }
     

--- a/tests/LineComment.cs
+++ b/tests/LineComment.cs
@@ -1,6 +1,7 @@
 namespace Demo {
     public partial class Foo {
         public void Test() {
+            // leading comment
             var i = 1;
         }
     }

--- a/tests/MultiVars.cs
+++ b/tests/MultiVars.cs
@@ -9,7 +9,7 @@ namespace Demo {
         }
         public static void SplitDecl() {
             string s105_deposito_FGTS;
-            string s106_base_calc_FGTS;
+            string s106_base_calc_FGTS; // comment on same line
             string s107_total_proventos;
             System.Console.WriteLine(s107_total_proventos);
         }

--- a/tests/StrayBrace.cs
+++ b/tests/StrayBrace.cs
@@ -3,6 +3,7 @@ namespace Demo {
         public static void Demo() {
             System.Console.WriteLine("hi");
             System.Console.WriteLine("there");
+            /* System.Console.WriteLine('ignored'); */
         }
     }
 }

--- a/transformer.py
+++ b/transformer.py
@@ -70,6 +70,20 @@ class ToCSharp(Transformer):
             return '.'.join(escape_cs_keyword(p) for p in parts)
         return escape_cs_keyword(text)
 
+    # ── comments ──────────────────────────────────────────────
+    def comment(self, tok):
+        text = str(tok)
+        if text.startswith('{') and text.endswith('}'):
+            inner = text[1:-1].strip()
+            return f"/* {inner} */"
+        if text.startswith('(*') and text.endswith('*)'):
+            inner = text[2:-2].strip()
+            return f"/* {inner} */"
+        return text
+
+    def comment_stmt(self, comment):
+        return str(comment)
+
     def attributes(self, *items):
         return list(items)
 
@@ -653,7 +667,16 @@ class ToCSharp(Transformer):
     def var_stmt(self, *decls):
         return "\n".join(decls)
 
-    def var_decl(self, names, typ, expr=None):
+    def var_decl(self, names, typ, *parts):
+        expr = None
+        comment = None
+        if len(parts) == 1:
+            if isinstance(parts[0], str) and (parts[0].startswith('//') or parts[0].startswith('/*')):
+                comment = parts[0]
+            else:
+                expr = parts[0]
+        elif len(parts) == 2:
+            expr, comment = parts
         t = map_type_ext(str(typ))
         safe_names = [self._safe_name(n) for n in names]
         decl = f"{t} {', '.join(safe_names)}"
@@ -661,14 +684,20 @@ class ToCSharp(Transformer):
             decl += f" = {expr}"
         for n in safe_names:
             self.curr_locals.add(str(n))
-        return decl + ";"
+        line = decl + ";"
+        if comment:
+            line += " " + str(comment)
+        return line
 
-    def var_decl_infer(self, names, expr):
+    def var_decl_infer(self, names, expr, comment=None):
         safe_names = [self._safe_name(n) for n in names]
         decl = f"var {', '.join(safe_names)} = {expr}"
         for n in safe_names:
             self.curr_locals.add(str(n))
-        return decl + ";"
+        line = decl + ";"
+        if comment:
+            line += " " + str(comment)
+        return line
 
     def field_decl(self, *parts):
         is_static = self.curr_static
@@ -685,6 +714,9 @@ class ToCSharp(Transformer):
                 items.append(p)
                 continue
             items.append(p)
+        comment = None
+        if items and isinstance(items[-1], str) and (items[-1].startswith('//') or items[-1].startswith('/*')):
+            comment = items.pop()
         if len(items) == 3:
             names, typ, expr = items
         else:
@@ -703,6 +735,8 @@ class ToCSharp(Transformer):
             body = "\n".join(attrs + [impl])
         else:
             body = impl
+        if comment:
+            body = body + " " + str(comment)
         if self.emit_comments:
             return info + "\n" + body
         return body
@@ -1047,13 +1081,29 @@ class ToCSharp(Transformer):
             then_part = "{}"
         else:
             then_part = then_block
-        if else_clause is None:
+
+        comment_only = False
+        comment_text = None
+        if else_clause is not None:
+            text = str(else_clause).strip()
+            if text and (text.startswith("//") or text.startswith("/*")):
+                comment_only = True
+                comment_text = text
+
+        if else_clause is None or comment_only:
             else_part = ""
         elif not str(else_clause).strip():
             else_part = " else {}"
         else:
             else_part = f" else {else_clause}"
-        return f"if ({cond}) {then_part}{else_part}"
+
+        result = f"if ({cond}) {then_part}{else_part}"
+        if comment_only:
+            if result.endswith(";"):
+                result += " " + comment_text
+            else:
+                result += "\n" + comment_text
+        return result
 
     def for_stmt(self, var, *parts):
         parts = list(parts)


### PR DESCRIPTION
## Summary
- allow comment statements within class member sections so region directives parse
- add region comment example in `Comments.pas`
- update expected output for comments

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_comments tests/test_transpile.py::TranspileTests::test_line_comment tests/test_transpile.py::TranspileTests::test_multi_vars tests/test_transpile.py::TranspileTests::test_if_statements -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686418cbe8b883318c4aa9212f77f9ce