### PR TITLE
Handle comments in var sections

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -309,7 +309,8 @@ inherited_var: INHERITED name_base (ARRAY_RANGE | "." name_term)* -> inherited_v
 var_ref:     name_base (ARRAY_RANGE | "." name_term)* -> var
            | "(" expr ")" ARRAY_RANGE -> paren_index
 
-var_section: ("var"i | "threadvar"i) (var_decl | var_decl_infer)+
+var_section: ("var"i | "threadvar"i) var_section_item+
+var_section_item: var_decl | var_decl_infer | comment_stmt
 var_decl:    name_list ":" type_spec (":=" expr)? ";" comment?       -> var_decl
 var_decl_infer: name_list ":=" expr ";" comment?                 -> var_decl_infer
 

--- a/tests/VarSectionComment.cs
+++ b/tests/VarSectionComment.cs
@@ -1,0 +1,9 @@
+namespace Demo {
+    public partial class VarSectionComment {
+        public void Demo() {
+            // comment before var declaration
+            int i;
+            i = 1;
+        }
+    }
+}

--- a/tests/VarSectionComment.pas
+++ b/tests/VarSectionComment.pas
@@ -1,0 +1,19 @@
+namespace Demo;
+
+type
+  VarSectionComment = public class
+  public
+    method Demo;
+  end;
+
+implementation
+
+method VarSectionComment.Demo;
+var
+  // comment before var declaration
+  i: Integer;
+begin
+  i := 1;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -772,6 +772,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_var_section_comment(self):
+        src = Path('tests/VarSectionComment.pas').read_text()
+        expected = Path('tests/VarSectionComment.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
 
 
     def test_safe_print_cp1252(self):

--- a/transformer.py
+++ b/transformer.py
@@ -658,6 +658,9 @@ class ToCSharp(Transformer):
     def var_section(self, *decls):
         return "\n".join(decls)
 
+    def var_section_item(self, item):
+        return item
+
     def pre_class_decl(self, item):
         return item
 


### PR DESCRIPTION
## Summary
- support comments inside `var` sections
- add tests for var section comments

## Testing
- `pytest -q`
- `pytest -q tests/test_transpile.py::TranspileTests::test_var_section_comment`


------
https://chatgpt.com/codex/tasks/task_e_68642d5912ec83319ae516857fb67594