### PR TITLE
Skip interface #region comments

### DIFF
--- a/tests/Comments.cs
+++ b/tests/Comments.cs
@@ -10,8 +10,6 @@ namespace Demo {
     }
     
     public partial class Foo {
-        /* $REGION 'extra' */
-        /* $ENDREGION */
         public int ValueParen() {
             int result;
             /* comment with *** inside

--- a/transformer.py
+++ b/transformer.py
@@ -136,6 +136,8 @@ class ToCSharp(Transformer):
             kind, base, sign_list, mods = self.class_defs.get(cname, ("class", "", [], set()))
             body_lines = []
             for line in sign_list:
+                if 'region' in line.lower():
+                    continue
                 info = self._parse_sig(line)
                 if info and info in self.impl_methods.get(cname, set()):
                     continue


### PR DESCRIPTION
## Summary
- avoid emitting region comments from interface declarations
- update region comment test expectation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68642dbff8688331881f0f6e6701ed2f