### PR TITLE
Allow assembly attributes anywhere in interface section

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -2,7 +2,7 @@
 GRAMMAR = r"""
 ?start:   assembly_attr* (namespace | unit_decl | program_decl | library_decl) uses_clause? (interface_section | pre_class_decl*)? class_section* ("implementation" uses_clause? class_impl*)? (main_block "." | initialization_section? ("end"i ("." | ";"))?)
 main_block: "begin" stmt* "end"i
-interface_section: "interface" uses_clause? assembly_attr* pre_class_decl*
+interface_section: "interface" uses_clause? pre_class_decl*
 uses_clause:   "uses" dotted_name ("," dotted_name)* ";"       -> uses
 
 assembly_attr: "[" CNAME ":" dotted_name ("(" arg_list? ")")? "]" ";"?
@@ -126,6 +126,7 @@ pre_class_decl: const_block
               | var_section
               | method_decl_rule
               | comment_stmt
+              | assembly_attr
 
 class_impl:  attributes? class_modifier? method_kind method_impl
            | comment_stmt
@@ -333,7 +334,7 @@ inherited_var: INHERITED name_base (ARRAY_RANGE | "." name_term)* -> inherited_v
 var_ref:     name_base (ARRAY_RANGE | "." name_term)* -> var
            | "(" expr ")" ARRAY_RANGE -> paren_index
 
-var_section: ("var"i | "threadvar"i) (var_decl | var_decl_infer)+
+var_section: ("var"i | "threadvar"i) var_section_item+
 var_section_item: var_decl | var_decl_infer | comment_stmt
 var_decl:    name_list ":" type_spec (":=" expr)? ";" comment?       -> var_decl
 var_decl_infer: name_list ":=" expr ";" comment?                 -> var_decl_infer

--- a/transformer.py
+++ b/transformer.py
@@ -145,8 +145,6 @@ class ToCSharp(Transformer):
             kind, base, sign_list, mods = self.class_defs.get(cname, ("class", "", [], set()))
             body_lines = []
             for line in sign_list:
-                if 'region' in line.lower():
-                    continue
                 info = self._parse_sig(line)
                 if info and info in self.impl_methods.get(cname, set()):
                     continue


### PR DESCRIPTION
## Summary
- support `[assembly: ...]` inside interface sections after comments or other items
- allow comments before variable declarations
- keep region directives when generating class members

## Testing
- `pytest -q tests/test_transpile.py::TranspileTests::test_assembly_attr`
- `pytest -q tests/test_transpile.py::TranspileTests::test_assembly_protected`
- `pytest -q tests/test_transpile.py::TranspileTests::test_comments`
- `pytest -q tests/test_transpile.py::TranspileTests::test_var_section_comment`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643152bcd88331be096b284ea930a9