### PR TITLE
Support leading comments

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -1,6 +1,6 @@
 # ────────────────────────── Grammar ──────────────────────────
 GRAMMAR = r"""
-?start:   assembly_attr* (namespace | unit_decl | program_decl | library_decl) uses_clause? (interface_section | pre_class_decl*)? class_section* ("implementation" uses_clause? class_impl*)? (main_block "." | initialization_section? ("end"i ("." | ";"))?)
+?start:   comment* assembly_attr* (namespace | unit_decl | program_decl | library_decl) uses_clause? (interface_section | pre_class_decl*)? class_section* ("implementation" uses_clause? class_impl*)? (main_block "." | initialization_section? ("end"i ("." | ";"))?)
 main_block: "begin" stmt* "end"i
 interface_section: "interface" uses_clause? assembly_attr* pre_class_decl*
 uses_clause:   "uses" dotted_name ("," dotted_name)* ";"       -> uses
@@ -333,7 +333,7 @@ inherited_var: INHERITED name_base (ARRAY_RANGE | "." name_term)* -> inherited_v
 var_ref:     name_base (ARRAY_RANGE | "." name_term)* -> var
            | "(" expr ")" ARRAY_RANGE -> paren_index
 
-var_section: ("var"i | "threadvar"i) (var_decl | var_decl_infer)+
+var_section: ("var"i | "threadvar"i) var_section_item+
 var_section_item: var_decl | var_decl_infer | comment_stmt
 var_decl:    name_list ":" type_spec (":=" expr)? ";" comment?       -> var_decl
 var_decl_infer: name_list ":=" expr ";" comment?                 -> var_decl_infer

--- a/tests/FileHeader.cs
+++ b/tests/FileHeader.cs
@@ -1,0 +1,6 @@
+namespace Demo.Header {
+    public partial class FileHeader {
+        public void Hello() {
+        }
+    }
+}

--- a/tests/FileHeader.pas
+++ b/tests/FileHeader.pas
@@ -1,0 +1,20 @@
+{ initial comment }
+{$HIDE CW3}
+
+namespace Demo.Header;
+
+interface
+
+type
+  FileHeader = class
+  public
+    method Hello;
+  end;
+
+implementation
+
+method FileHeader.Hello;
+begin
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -52,6 +52,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_file_header(self):
+        src = Path('tests/FileHeader.pas').read_text()
+        expected = Path('tests/FileHeader.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_keyword_prefix(self):
         src = Path('tests/KeywordPrefix.pas').read_text()
         expected = Path('tests/KeywordPrefix.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -138,15 +138,13 @@ class ToCSharp(Transformer):
         return ""
 
     # ── root rule -------------------------------------------------
-    def start(self, ns, *parts):
+    def start(self, *parts):
         classes = []
         first_class = True
         for cname in self.class_order:
             kind, base, sign_list, mods = self.class_defs.get(cname, ("class", "", [], set()))
             body_lines = []
             for line in sign_list:
-                if 'region' in line.lower():
-                    continue
                 info = self._parse_sig(line)
                 if info and info in self.impl_methods.get(cname, set()):
                     continue


### PR DESCRIPTION
## Summary
- allow comments before namespace declarations
- retain #region blocks in output
- test parsing with a file header comment

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_file_header -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864323750d08331908c2b4c71e45dcd