### PR TITLE
Fix parsing of trailing comments on assignments

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -185,9 +185,9 @@ block:       "begin" ";"? stmt* "end"i ";"?
                 | block
            
 
-assign_stmt: (inherited_var | var_ref | call_lhs) ":=" expr ";"? -> assign
-op_assign_stmt: (var_ref | call_lhs) ADD_ASSIGN expr ";"?              -> op_assign
-              | (var_ref | call_lhs) SUB_ASSIGN expr ";"?              -> op_assign
+assign_stmt: (inherited_var | var_ref | call_lhs) ":=" expr ";"? comment? -> assign
+op_assign_stmt: (var_ref | call_lhs) ADD_ASSIGN expr ";"? comment?              -> op_assign
+              | (var_ref | call_lhs) SUB_ASSIGN expr ";"? comment?              -> op_assign
 return_stmt: RESULT ":=" expr ";"?                      -> result_ret
            | EXIT expr? ";"?                            -> exit_ret
 raise_stmt: RAISE expr? ";"?                           -> raise_stmt

--- a/tests/IfStatements.cs
+++ b/tests/IfStatements.cs
@@ -47,4 +47,15 @@ namespace Demo {
             return result;
         }
     }
+    
+    public partial class PadZeros {
+        public static string PreencheComZeros(double n, int t) {
+            string result;
+            string aux;
+            aux = n.ToString;
+            if (Length(aux) > t) aux = Copy(aux, 0, t); // pega as primeiras t posicoes else aux = TSGUutils.Replicar("0", t - Length(aux)) + aux; // preenche com zeros
+            result = aux;
+            return result;
+        }
+    }
 }

--- a/tests/IfStatements.pas
+++ b/tests/IfStatements.pas
@@ -33,6 +33,11 @@ type
     method Check(frowInd: Integer): Boolean;
   end;
 
+  PadZeros = class
+  public
+    class method PreencheComZeros(n: Extended; t: Integer): String;
+  end;
+
 implementation
 
 class method Ternary.Select(flag: Boolean): Integer;
@@ -76,6 +81,17 @@ begin
     result := true
   else
     result := false;
+end;
+
+class method PadZeros.PreencheComZeros(n: Extended; t: Integer): String;
+var aux: String;
+begin
+  aux := n.ToString;
+  if Length(aux) > t then
+    aux := Copy(aux,0,t)   // pega as primeiras t posicoes
+  else
+    aux := TSGUutils.Replicar('0',t-Length(aux)) + aux;   // preenche com zeros
+  result := aux;
 end;
 
 end.

--- a/transformer.py
+++ b/transformer.py
@@ -1003,11 +1003,17 @@ class ToCSharp(Transformer):
         return (cls, name, ", ".join(param_list), self.curr_rettype)
 
     # ── statements ──────────────────────────────────────────
-    def assign(self, var, expr):
-        return f"{var} = {expr};"
+    def assign(self, var, expr, comment=None):
+        line = f"{var} = {expr};"
+        if comment:
+            line += " " + str(comment)
+        return line
 
-    def op_assign(self, var, op, expr):
-        return f"{var} {op} {expr};"
+    def op_assign(self, var, op, expr, comment=None):
+        line = f"{var} {op} {expr};"
+        if comment:
+            line += " " + str(comment)
+        return line
 
     def result_ret(self, _tok, expr):
         self.used_result = True


### PR DESCRIPTION
## Summary
- allow comments directly after assignment statements in the grammar
- preserve those comments in the generated C# by adjusting `assign` and `op_assign`
- add Pascal/C# sample in `IfStatements` exercising assignments with trailing comments

## Testing
- `pytest -q tests/test_transpile.py::TranspileTests::test_if_statements -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686436a421ec83319402c2906750088f