### PR TITLE
Allow comments after method headers

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -131,7 +131,7 @@ pre_class_decl: const_block
 
 class_impl:  attributes? class_modifier? method_kind method_impl
            | comment_stmt
-method_impl: attributes? impl_head ";" method_decls? block               -> m_impl
+method_impl: attributes? impl_head ";" comment* method_decls? block       -> m_impl
 method_decls: (var_section | const_block)+
 impl_head:   method_name param_block? return_block?
 

--- a/tests/Comments.cs
+++ b/tests/Comments.cs
@@ -33,6 +33,11 @@ namespace Demo {
             result = 123;
             return result;
         }
+        public void HeaderLineComment() {
+            // header comment
+            int i;
+            i = 1;
+        }
     }
     
     /// <remarks>

--- a/tests/Comments.pas
+++ b/tests/Comments.pas
@@ -16,7 +16,8 @@ type
     {$REGION 'extra'}
     method ValueBrace: Integer;
     {$ENDREGION}
-    method ValueCStyle: Integer;
+  method ValueCStyle: Integer;
+  method HeaderLineComment;
   end;
 
   /// <remarks>
@@ -53,6 +54,13 @@ begin
   /* comment
      multiple lines */
   result := 123;
+end;
+
+method Foo.HeaderLineComment; // header comment
+var
+  i: Integer;
+begin
+  i := 1;
 end;
 
 end.

--- a/transformer.py
+++ b/transformer.py
@@ -894,11 +894,28 @@ class ToCSharp(Transformer):
             parts = parts[1:]
         head = parts[0]
         tail = parts[1:]
+        comments = []
+        while tail and (
+            (isinstance(tail[0], Token) and tail[0].type.startswith("COMMENT"))
+            or (isinstance(tail[0], str) and tail[0].lstrip().startswith(('/', '#')))
+        ):
+            tok = tail[0]
+            if isinstance(tok, Token):
+                comments.append(self.comment(tok))
+            else:
+                comments.append(tok)
+            tail = tail[1:]
         if len(tail) == 1:
             vars_code = ""
             body = tail[0]
         else:
             vars_code, body = tail
+        if comments:
+            c_text = "\n".join(comments)
+            if vars_code:
+                vars_code = c_text + "\n" + vars_code
+            else:
+                vars_code = c_text
         cls, name, params, rettype = head
         params_cs = params or ""
         ret       = map_type_ext(rettype) if rettype else "void"


### PR DESCRIPTION
## Summary
- adjust grammar to accept comments after method headers
- ensure transformer handles header comments
- test handling by adding a new case in `Comments` example

## Testing
- `pytest -q`
- `pytest tests/test_transpile.py::TranspileTests::test_comments -q`


------
https://chatgpt.com/codex/tasks/task_e_686437e1980c8331a051973138169bde