### PR TITLE
Handle class var sections

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -55,6 +55,7 @@ member_decl: attributes? method_decl_rule
            | attributes? access_modifier? (CLASSVAR | VAR) attributes? name_list ":" type_spec (":=" expr)? ";" comment?      -> field_decl
            | attributes? access_modifier? class_modifier attributes? name_list ":" type_spec (":=" expr)? ";" comment?      -> field_decl
            | access_modifier? name_list ":" type_spec (":=" expr)? ";" comment?      -> field_decl
+           | VAR                                                            -> var_kwd
            | comment_stmt
 
            | attributes? access_modifier? "class"? "property"i property_sig ";" (method_attr ";")*      -> property_decl

--- a/tests/ClassVarSection.cs
+++ b/tests/ClassVarSection.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class VarGroup {
+        public static int Log;
+        public int Value;
+        public bool Flag;
+    }
+}

--- a/tests/ClassVarSection.pas
+++ b/tests/ClassVarSection.pas
@@ -1,0 +1,14 @@
+namespace Demo;
+
+type
+  VarGroup = class
+  private
+    class var Log: Integer;
+    var
+      Value: Integer;
+      Flag: Boolean;
+  end;
+
+implementation
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -312,6 +312,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_class_var_section(self):
+        src = Path('tests/ClassVarSection.pas').read_text()
+        expected = Path('tests/ClassVarSection.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_new_args(self):
         src = Path('tests/NewArgs.pas').read_text()
         expected = Path('tests/NewArgs.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -663,6 +663,9 @@ class ToCSharp(Transformer):
     def section(self, token=None):
         return ""
 
+    def var_kwd(self, *args):
+        return ""
+
     def method_kind(self, token=None):
         self.curr_kind = str(token) if token else None
         return ""


### PR DESCRIPTION
## Summary
- allow bare `var` inside class signatures
- ignore `var` sections when building C#
- add tests for class var sections

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_class_var_section -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68643aefa8688331b52f00602b0debd5