### PR TITLE
Support comments in conditional expressions

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -314,13 +314,13 @@ GT:           ">"
 GENERIC_ARGS: /<[A-Za-z_][^<>]*(?:<[^<>]*>[^<>]*)*>/
 ASSEMBLY.3:  "assembly"i
 ANDKW.3:     "and"i
-OP_SUM:       "+" | "-" | "or" | "xor"i
-OP_MUL:       "*" | "/" | "and" | "mod"i | "div"i
+OP_SUM.2:     "+" | "-" | "or" | "xor"i
+OP_MUL.2:     "*" | "/" | "and" | "mod"i | "div"i
 OP_REL:       "=" | "<>" | "<=" | ">="
 SHL:          "shl"i
 SHR:          "shr"i
-ADD_ASSIGN.2:  "+="
-SUB_ASSIGN.2:  "-="
+ADD_ASSIGN.3:  "+="
+SUB_ASSIGN.3:  "-="
 
 NOT:         "not"i
 METHOD:      "method"i

--- a/tests/IfComment.cs
+++ b/tests/IfComment.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class IfComment {
+        public static void Demo(int x) {
+            if (x == 1 || x == 2) System.Console.WriteLine("Yes");
+        }
+    }
+}

--- a/tests/IfComment.pas
+++ b/tests/IfComment.pas
@@ -1,0 +1,17 @@
+namespace Demo;
+
+type
+  IfComment = public class
+  public
+    class method Demo(x: Integer);
+  end;
+
+implementation
+
+class method IfComment.Demo(x: Integer);
+begin
+  if (x = 1) or (x = 2) { or (x = 3) or (x = 4)} then
+    System.Console.WriteLine('Yes');
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -101,6 +101,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_if_comment(self):
+        src = Path('tests/IfComment.pas').read_text()
+        expected = Path('tests/IfComment.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_generics(self):
         src = Path('tests/Generics.pas').read_text()
         expected = Path('tests/Generics.cs').read_text().strip()


### PR DESCRIPTION
## Summary
- ensure assignment operators tokenize correctly by adjusting grammar token order
- add regression test for comments within if condition

## Testing
- `pytest -q`
- `pytest tests/test_transpile.py::TranspileTests::test_if_comment -q`
- `pytest tests/test_user_parse_errors.py::NewFeatureTests::test_op_assign -q`


------
https://chatgpt.com/codex/tasks/task_e_6865150e29208331a52e24f120faa373