### PR TITLE
Allow comments before THEN in if statements

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -204,7 +204,7 @@ with_stmt: WITH expr DO stmt                           -> with_stmt
 yield_stmt: YIELD expr ";"?                           -> yield_stmt
 empty_stmt: ";"                                      -> empty
 comment_stmt: comment                                -> comment_stmt
-if_stmt:     "if"i expr THEN comment_stmt* (stmt_no_comment | empty_stmt)? else_clause?        -> if_stmt
+if_stmt:     "if"i expr comment_stmt* THEN comment_stmt* (stmt_no_comment | empty_stmt)? else_clause?        -> if_stmt
 else_clause: ELSE comment_stmt* stmt_no_comment                           -> else_clause
            | ELSE comment_stmt*                                -> else_clause_empty
 for_stmt:    "for"i CNAME (":" type_spec)? ":=" expr (TO | DOWNTO) expr (STEP expr)? ("do"i)? stmt  -> for_stmt

--- a/tests/IfExprComment.cs
+++ b/tests/IfExprComment.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Demo {
+    public partial class ExprComment {
+        public static void Check(int cc) {
+            if (cc == 1) /* or cc = 2 */
+            Console.WriteLine("y");
+        }
+    }
+}

--- a/tests/IfExprComment.pas
+++ b/tests/IfExprComment.pas
@@ -1,0 +1,21 @@
+namespace Demo;
+
+interface
+
+uses System;
+
+type
+  ExprComment = class
+  public
+    class method Check(cc: Integer);
+  end;
+
+implementation
+
+class method ExprComment.Check(cc: Integer);
+begin
+  if (cc = 1) { or cc = 2 } then
+    Console.WriteLine('y');
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -59,6 +59,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_if_expr_comment(self):
+        src = Path('tests/IfExprComment.pas').read_text()
+        expected = Path('tests/IfExprComment.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_file_header(self):
         src = Path('tests/FileHeader.pas').read_text()
         expected = Path('tests/FileHeader.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -1136,10 +1136,14 @@ class ToCSharp(Transformer):
 
     def if_stmt(self, cond, *parts):
         parts = list(parts)
+        comments = []
+
+        while parts and isinstance(parts[0], str) and (parts[0].startswith("//") or parts[0].startswith("/*")):
+            comments.append(parts.pop(0))
+
         if parts and isinstance(parts[0], Token):
             parts.pop(0)
 
-        comments = []
         while parts and isinstance(parts[0], str) and (parts[0].startswith("//") or parts[0].startswith("/*")):
             comments.append(parts.pop(0))
 


### PR DESCRIPTION
## Summary
- handle comments between condition and `then` in `if` statements
- keep comment placement when transpiling
- cover this behaviour with new tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686525f57d208331847415ec255ee6f6