### PR TITLE
Handle comments within expressions

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -243,20 +243,20 @@ inherited_stmt: INHERITED (name_term ("(" arg_list? ")" call_postfix*)?)? ";"? -
            | "-" expr                                -> neg
            | "+" expr                                -> pos
            | AT var_ref                              -> addr_of
-           | expr OP_SUM   expr                      -> binop
-           | expr OP_MUL   expr                      -> binop
-           | expr SHL expr                          -> binop
-           | expr SHR expr                          -> binop
-           | expr OP_SUM ELSE expr                   -> short_or
-           | expr OP_MUL THEN expr                   -> short_and
+           | expr expr_comment* OP_SUM expr_comment* expr      -> binop
+           | expr expr_comment* OP_MUL expr_comment* expr      -> binop
+           | expr expr_comment* SHL expr_comment* expr         -> binop
+           | expr expr_comment* SHR expr_comment* expr         -> binop
+           | expr expr_comment* OP_SUM expr_comment* ELSE expr_comment* expr -> short_or
+           | expr expr_comment* OP_MUL expr_comment* THEN expr_comment* expr -> short_and
            | "if"i expr THEN expr ELSE expr       -> if_expr
            | "if"i expr THEN expr                  -> if_expr_short
-           | expr (OP_REL|LT|GT) expr                -> binop
-           | expr IN set_lit                         -> in_expr
-           | expr NOT IN set_lit                     -> not_in_expr
-           | expr IS NOT type_spec                   -> is_not_inst
-           | expr IS type_spec                       -> is_inst
-           | expr AS type_spec                       -> as_cast
+           | expr expr_comment* (OP_REL|LT|GT) expr_comment* expr -> binop
+           | expr expr_comment* IN expr_comment* set_lit       -> in_expr
+           | expr expr_comment* NOT expr_comment* IN expr_comment* set_lit -> not_in_expr
+           | expr expr_comment* IS expr_comment* NOT expr_comment* type_spec -> is_not_inst
+           | expr expr_comment* IS expr_comment* type_spec     -> is_inst
+           | expr expr_comment* AS expr_comment* type_spec     -> as_cast
            | "(" expr ")"
            | NUMBER                                  -> number
            | HEX_NUMBER                              -> hex_number
@@ -453,8 +453,13 @@ COMMENT_STAR.4: /\/\*[\s\S]*?\*\//
 %ignore WS
 %ignore /\}/
 
-comment: COMMENT_BRACE
+comment.2: COMMENT_BRACE
        | COMMENT_PAREN
        | COMMENT_STAR
        | LINE_COMMENT
+
+expr_comment.1: COMMENT_BRACE
+            | COMMENT_PAREN
+            | COMMENT_STAR
+            | LINE_COMMENT
 """

--- a/tests/ExprComment.cs
+++ b/tests/ExprComment.cs
@@ -1,0 +1,7 @@
+namespace Demo {
+    public partial class ExprComment {
+        public static void Check(bool flag1, bool flag2) {
+            if (flag1 || flag2) System.Console.WriteLine("y");
+        }
+    }
+}

--- a/tests/ExprComment.pas
+++ b/tests/ExprComment.pas
@@ -1,0 +1,17 @@
+namespace Demo;
+
+type
+  ExprComment = public class
+  public
+    class method Check(flag1: Boolean; flag2: Boolean);
+  end;
+
+implementation
+
+class method ExprComment.Check(flag1: Boolean; flag2: Boolean);
+begin
+  if flag1 or { comment } flag2 then
+    System.Console.WriteLine('y');
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -59,6 +59,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_expr_comment(self):
+        src = Path('tests/ExprComment.pas').read_text()
+        expected = Path('tests/ExprComment.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_file_header(self):
         src = Path('tests/FileHeader.pas').read_text()
         expected = Path('tests/FileHeader.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -89,6 +89,10 @@ class ToCSharp(Transformer):
             return f"/* {inner} */"
         return text
 
+    def expr_comment(self, tok):
+        # Ignore comments embedded within expressions
+        return ''
+
     def comment_stmt(self, comment):
         return str(comment)
 
@@ -1375,7 +1379,10 @@ class ToCSharp(Transformer):
         return ""
 
     # ── expressions ─────────────────────────────────────────
-    def binop(self, left, op, right):
+    def binop(self, *parts):
+        # Filter out empty strings from inline comments
+        cleaned = [p for p in parts if not (isinstance(p, str) and p == '')]
+        left, op, right = cleaned[0], cleaned[1], cleaned[2]
         op_map = {
             "and": "&&",
             "or": "||",


### PR DESCRIPTION
## Summary
- allow comments between expression terms in grammar
- ignore inline comments during expression translation
- test comment inside boolean expression

## Testing
- `pytest -k expr_comment -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865260ab66c8331a608c428a32db35a