### PR TITLE
Fix comment handling for Result assignments

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -189,7 +189,7 @@ block:       "begin" ";"? stmt* "end"i comment* ";"?
 assign_stmt: (inherited_var | var_ref | call_lhs) ":=" expr ";"? comment? -> assign
 op_assign_stmt: (var_ref | call_lhs) ADD_ASSIGN expr ";"? comment?              -> op_assign
               | (var_ref | call_lhs) SUB_ASSIGN expr ";"? comment?              -> op_assign
-return_stmt: RESULT ":=" expr ";"?                      -> result_ret
+return_stmt: RESULT ":=" expr ";"? comment?             -> result_ret
            | EXIT expr? ";"?                            -> exit_ret
 raise_stmt: RAISE expr? ";"?                           -> raise_stmt
 repeat_stmt: "repeat"i stmt* "until"i expr ";"?         -> repeat_stmt

--- a/tests/IfStatements.cs
+++ b/tests/IfStatements.cs
@@ -53,7 +53,8 @@ namespace Demo {
             string result;
             string aux;
             aux = n.ToString;
-            if (Length(aux) > t) aux = Copy(aux, 0, t); // pega as primeiras t posicoes else aux = TSGUutils.Replicar("0", t - Length(aux)) + aux; // preenche com zeros
+            if (Length(aux) > t) aux = Copy(aux, 0, t); // pega as primeiras t posicoes
+            else aux = TSGUutils.Replicar("0", t - Length(aux)) + aux; // preenche com zeros
             result = aux;
             return result;
         }

--- a/tests/ReturnOnly.cs
+++ b/tests/ReturnOnly.cs
@@ -5,5 +5,12 @@ namespace Test {
             result = 1;
             return result;
         }
+        public string TipoFonte() {
+            string result;
+            if (fonteAux.tipo.trim == "0") result = "P"; //Fonte PUC
+            else if (fonteAux.tipo.trim == "1") result = "C"; //Fonte Convenio
+            else result = "J"; //Fonte Projeto
+            return result;
+        }
     }
 }

--- a/tests/ReturnOnly.pas
+++ b/tests/ReturnOnly.pas
@@ -4,6 +4,7 @@ interface
 type
   Foo = public class
     function Bar : Integer;
+    function TipoFonte: String;
   end;
 
 implementation
@@ -11,6 +12,17 @@ implementation
 function Foo.Bar : Integer;
 begin
   result := 1;
+end;
+
+function Foo.TipoFonte: String;
+begin
+  if fonteAux.tipo.trim = '0' then
+    result := 'P' //Fonte PUC
+  else
+    if fonteAux.tipo.trim = '1' then
+      result := 'C' //Fonte Convênio
+    else
+      result := 'J'; //Fonte Projeto
 end;
 
 end.

--- a/transformer.py
+++ b/transformer.py
@@ -1037,9 +1037,12 @@ class ToCSharp(Transformer):
             line += " " + str(comment)
         return line
 
-    def result_ret(self, _tok, expr):
+    def result_ret(self, _tok, expr, comment=None):
         self.used_result = True
-        return f"result = {expr};"
+        line = f"result = {expr};"
+        if comment:
+            line += " " + str(comment)
+        return line
 
     def exit_ret(self, _tok, expr=None):
         return f"return{(' ' + expr) if expr else ''};"
@@ -1185,7 +1188,14 @@ class ToCSharp(Transformer):
         else:
             else_part = f" else {else_clause}"
 
-        result = f"if ({cond}) {then_part}{else_part}"
+        result = f"if ({cond}) {then_part}"
+        if else_part:
+            last_line = str(then_part).split("\n")[-1]
+            if "//" in last_line or "/*" in last_line:
+                result += "\n" + else_part.lstrip()
+            else:
+                result += else_part
+        
         if comment_only:
             if result.endswith(";"):
                 result += " " + comment_text


### PR DESCRIPTION
## Summary
- support trailing comments on `result :=` statements in grammar
- emit those comments in `result_ret`
- handle `else` placement when a line ends with a comment
- update `IfStatements.cs` and `ReturnOnly.cs` expectations

## Testing
- `pytest tests/test_user_parse_errors.py::NewFeatureTests::test_if_or -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686536554ea48331b38cdc9f9f8d3454