### PR TITLE
Allow trailing comments before else

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -204,8 +204,8 @@ with_stmt: WITH expr DO stmt                           -> with_stmt
 yield_stmt: YIELD expr ";"?                           -> yield_stmt
 empty_stmt: ";"                                      -> empty
 comment_stmt: comment                                -> comment_stmt
-if_stmt:     "if"i expr expr_comment* comment_stmt* THEN comment_stmt* (stmt_no_comment | empty_stmt)? else_clause?        -> if_stmt
-else_clause: ELSE comment_stmt* stmt_no_comment                           -> else_clause
+if_stmt:     "if"i expr expr_comment* comment_stmt* THEN comment_stmt* (stmt_no_comment comment_stmt* | empty_stmt)? else_clause?        -> if_stmt
+else_clause: ELSE comment_stmt* stmt_no_comment comment_stmt*                           -> else_clause
            | ELSE comment_stmt*                                -> else_clause_empty
 for_stmt:    "for"i CNAME (":" type_spec)? ":=" expr (TO | DOWNTO) expr (STEP expr)? ("do"i)? stmt  -> for_stmt
            | "for"i "each"i? CNAME (":" type_spec)? IN expr (INDEX CNAME)? ("do"i)? stmt      -> for_each_stmt

--- a/tests/IfTrailingComment.cs
+++ b/tests/IfTrailingComment.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Demo {
+    public partial class IfTrailingComment {
+        public static void Check(bool flag) {
+            if (flag) Console.WriteLine("a"); // comment
+            else Console.WriteLine("b");
+        }
+    }
+}

--- a/tests/IfTrailingComment.pas
+++ b/tests/IfTrailingComment.pas
@@ -1,0 +1,23 @@
+namespace Demo;
+
+interface
+
+uses System;
+
+type
+  IfTrailingComment = class
+  public
+    class method Check(flag: Boolean);
+  end;
+
+implementation
+
+class method IfTrailingComment.Check(flag: Boolean);
+begin
+  if flag then
+    Console.WriteLine('a') // comment
+  else
+    Console.WriteLine('b');
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -59,6 +59,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_if_trailing_comment(self):
+        src = Path('tests/IfTrailingComment.pas').read_text()
+        expected = Path('tests/IfTrailingComment.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_if_expr_comment(self):
         src = Path('tests/IfExprComment.pas').read_text()
         expected = Path('tests/IfExprComment.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -1146,30 +1146,39 @@ class ToCSharp(Transformer):
 
     def if_stmt(self, cond, *parts):
         parts = list(parts)
-        comments = []
+        pre_comments = []
+        post_comments = []
 
         while parts and isinstance(parts[0], str) and (parts[0].startswith("//") or parts[0].startswith("/*")):
-            comments.append(parts.pop(0))
+            pre_comments.append(parts.pop(0))
 
         if parts and isinstance(parts[0], Token):
             parts.pop(0)
 
         while parts and isinstance(parts[0], str) and (parts[0].startswith("//") or parts[0].startswith("/*")):
-            comments.append(parts.pop(0))
+            pre_comments.append(parts.pop(0))
 
         then_block = None
         if parts:
             then_block = parts.pop(0)
 
+        while parts and isinstance(parts[0], str) and (parts[0].startswith("//") or parts[0].startswith("/*")):
+            post_comments.append(parts.pop(0))
+
         else_clause = None
         if parts:
             else_clause = parts.pop(0)
 
-        if comments:
+        if pre_comments:
             if then_block is not None and str(then_block).strip():
-                then_block = "\n".join(comments + [str(then_block)])
+                then_block = "\n".join(pre_comments + [str(then_block)])
             else:
-                then_block = "\n".join(comments)
+                then_block = "\n".join(pre_comments)
+        if post_comments:
+            if then_block is not None and str(then_block).strip():
+                then_block = str(then_block).rstrip() + " " + " ".join(post_comments)
+            else:
+                then_block = " ".join(post_comments)
 
         if then_block is None or not str(then_block).strip():
             then_part = "{}"


### PR DESCRIPTION
## Summary
- extend `if_stmt` grammar to accept comments after a single statement
- handle trailing comments in transformer so they remain on the same line
- add regression test for comment before `else`

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_if_trailing_comment -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686540dd8510833193324248d43183dc