### PR TITLE
Fix parsing comments before case labels

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -223,7 +223,7 @@ on_handler_type: ON type_name DO stmt -> on_handler_type
 case_stmt:   "case"i expr "of"i case_branch+ case_else? "end"i ";"? -> case_stmt
 case_else:   ELSE stmt+                           -> case_else
            | ELSE ";"?                          -> case_else_empty
-case_branch: case_label ("," case_label)* ":" stmt ";"?
+case_branch: comment_stmt* case_label ("," case_label)* ":" stmt ";"?
 signed_number: OP_SUM? NUMBER          -> signed_number
 case_label: signed_number DOTDOT signed_number        -> label_range
           | signed_number

--- a/tests/CaseComment.cs
+++ b/tests/CaseComment.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace Demo {
+    public partial class CaseComment {
+        public void Test(char val) {
+            switch (val)
+            {
+                //A
+                case 'A': Console.WriteLine("a"); break;
+                //B
+                case 'B': Console.WriteLine("b"); break;
+            }
+        }
+    }
+}
+

--- a/tests/CaseComment.pas
+++ b/tests/CaseComment.pas
@@ -1,0 +1,24 @@
+namespace Demo;
+
+uses System;
+
+type
+  CaseComment = public class
+  public
+    method Test(val: Char);
+  end;
+
+implementation
+
+method CaseComment.Test(val: Char);
+begin
+  case val of
+    //A
+    'A': Console.WriteLine('a');
+    //B
+    'B': Console.WriteLine('b');
+  end;
+end;
+
+end.
+

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -312,6 +312,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_case_comment(self):
+        src = Path('tests/CaseComment.pas').read_text()
+        expected = Path('tests/CaseComment.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_large_case_range(self):
         src = Path('tests/LargeCaseRange.pas').read_text()
         expected = Path('tests/LargeCaseRange.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -1348,7 +1348,9 @@ class ToCSharp(Transformer):
         else_branch = flat_else
 
         switch_body = []
-        for _tag, labels, stmt in branches:
+        for _tag, labels, stmt, comments in branches:
+            for c in comments:
+                switch_body.append(c)
             patterns = []
             for label in labels:
                 if isinstance(label, tuple) and label[0] == 'range':
@@ -1375,8 +1377,14 @@ class ToCSharp(Transformer):
 
     def case_branch(self, *parts):
         stmt = parts[-1]
-        labels = parts[:-1]
-        return ('branch', labels, stmt)
+        comments = []
+        labels = []
+        for p in parts[:-1]:
+            if isinstance(p, str) and (p.strip().startswith("//") or p.strip().startswith("/*") or p.strip().startswith("{")):
+                comments.append(p)
+            else:
+                labels.append(p)
+        return ('branch', labels, stmt, comments)
 
     def case_label(self, tok):
         if isinstance(tok, Token):


### PR DESCRIPTION
## Summary
- support comments before `case` labels in grammar
- handle those comments in the transformer
- add tests for case comments

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_case_comment -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68654263f1ec8331a13fd1328515adc8