### PR TITLE
Handle comments right after '(' in expressions

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -235,7 +235,7 @@ case_label: signed_number DOTDOT signed_number        -> label_range
 call_stmt:   var_ref ("(" arg_list? ")")? call_postfix* ";"?   -> call_stmt
            | generic_call_base ("(" arg_list? ")")? call_postfix* ";"? -> call_stmt
            | new_expr "." name_term ("(" arg_list? ")")? call_postfix* ";"?    -> call_stmt
-           | "(" expr ")" prop_call call_postfix* ";"? -> call_stmt
+           | "(" expr_comment* expr ")" prop_call call_postfix* ";"? -> call_stmt
 inherited_stmt: INHERITED (name_term ("(" arg_list? ")" call_postfix*)?)? ";"? -> inherited
 
 ?expr:       lambda_expr
@@ -257,7 +257,7 @@ inherited_stmt: INHERITED (name_term ("(" arg_list? ")" call_postfix*)?)? ";"? -
            | expr expr_comment* IS expr_comment* NOT expr_comment* type_spec -> is_not_inst
            | expr expr_comment* IS expr_comment* type_spec     -> is_inst
            | expr expr_comment* AS expr_comment* type_spec     -> as_cast
-           | "(" expr ")"
+           | "(" expr_comment* expr ")" -> paren_expr
            | NUMBER                                  -> number
            | HEX_NUMBER                              -> hex_number
            | BINARY_NUMBER                           -> binary_number
@@ -293,7 +293,7 @@ new_expr: "new" type_spec "(" arg_list? ")"         -> new_obj
         | "new" type_spec                           -> new_obj_noargs
 
 array_of_expr: "array"i "of"i type_name "(" arg_list? ")" -> array_of_expr
-typeof_expr: TYPEOF "(" expr ")"                        -> typeof_expr
+typeof_expr: TYPEOF "(" expr_comment* expr ")"                        -> typeof_expr
 
 generic_call_base: dotted_name GENERIC_ARGS
 
@@ -313,7 +313,7 @@ call_expr:   var_ref "(" arg_list? ")" call_postfix* -> call
            | generic_call_base ("(" arg_list? ")")? call_postfix* -> call
            | new_expr "." name_term GENERIC_ARGS? call_args? call_postfix* -> call
            | array_of_expr prop_call call_postfix* -> call
-           | "(" expr ")" prop_call call_postfix* -> call
+           | "(" expr_comment* expr ")" prop_call call_postfix* -> call
            | literal_string "." name_term GENERIC_ARGS? call_args? call_postfix* -> call
            | INHERITED name_term GENERIC_ARGS? call_args? call_postfix* -> inherited_call_expr
            | typeof_expr call_postfix+                     -> call
@@ -322,7 +322,7 @@ call_lhs:   var_ref "(" arg_list? ")" call_postfix+                 -> call
            | generic_call_base ("(" arg_list? ")")? call_postfix+    -> call
            | new_expr "." name_term GENERIC_ARGS? call_args? call_postfix+ -> call
            | array_of_expr prop_call call_postfix+ -> call
-           | "(" expr ")" prop_call call_postfix* -> call
+           | "(" expr_comment* expr ")" prop_call call_postfix* -> call
            | literal_string "." name_term GENERIC_ARGS? call_args? call_postfix+ -> call
            | typeof_expr call_postfix+                                 -> call
 arg_list:    arg ("," arg)*
@@ -335,7 +335,7 @@ arg:         OUT expr                                -> out_arg
 new_stmt:    new_expr ";"?
 inherited_var: INHERITED name_base (ARRAY_RANGE | "." name_term)* -> inherited_var
 var_ref:     name_base (ARRAY_RANGE | "." name_term)* -> var
-           | "(" expr ")" ARRAY_RANGE -> paren_index
+           | "(" expr_comment* expr ")" ARRAY_RANGE -> paren_index
 
 var_section: ("var"i | "threadvar"i) var_section_item+
 var_section_item: var_decl | var_decl_infer | comment_stmt

--- a/tests/ExprComment.cs
+++ b/tests/ExprComment.cs
@@ -3,5 +3,8 @@ namespace Demo {
         public static void Check(bool flag1, bool flag2) {
             if (flag1 || flag2) System.Console.WriteLine("y");
         }
+        public static void CheckStart(int flag1, int flag2) {
+            if (flag2 == 2) System.Console.WriteLine("z");
+        }
     }
 }

--- a/tests/ExprComment.pas
+++ b/tests/ExprComment.pas
@@ -4,6 +4,7 @@ type
   ExprComment = public class
   public
     class method Check(flag1: Boolean; flag2: Boolean);
+    class method CheckStart(flag1: Integer; flag2: Integer);
   end;
 
 implementation
@@ -12,6 +13,12 @@ class method ExprComment.Check(flag1: Boolean; flag2: Boolean);
 begin
   if flag1 or { comment } flag2 then
     System.Console.WriteLine('y');
+end;
+
+class method ExprComment.CheckStart(flag1: Integer; flag2: Integer);
+begin
+  if ({(flag1 = 1) or} (flag2 = 2)) then
+    System.Console.WriteLine('z');
 end;
 
 end.

--- a/transformer.py
+++ b/transformer.py
@@ -96,6 +96,16 @@ class ToCSharp(Transformer):
     def expr_with_comment(self, expr, *_comments):
         return expr
 
+    def paren_expr(self, *parts):
+        """Return the inner expression, ignoring leading comments."""
+        expr = ''
+        for p in parts:
+            if isinstance(p, str) and p == '':
+                continue
+            expr = p
+            break
+        return expr
+
     def comment_stmt(self, comment):
         return str(comment)
 


### PR DESCRIPTION
## Summary
- support comments immediately following an opening parenthesis
- keep inner expression when parentheses only wrap a comment
- test leading comment in an expression

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_expr_comment -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68654226834c8331bbbb93a1937daa37