### PR TITLE
Fix comments before case branch

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -223,7 +223,7 @@ on_handler_type: ON type_name DO stmt -> on_handler_type
 case_stmt:   "case"i expr "of"i case_branch+ case_else? "end"i ";"? -> case_stmt
 case_else:   ELSE stmt+                           -> case_else
            | ELSE ";"?                          -> case_else_empty
-case_branch: case_label ("," case_label)* ":" stmt ";"?
+case_branch: case_label ("," case_label)* ":" comment_stmt* stmt_no_comment ";"?
 signed_number: OP_SUM? NUMBER          -> signed_number
 case_label: signed_number DOTDOT signed_number        -> label_range
           | signed_number

--- a/tests/CaseStatements.cs
+++ b/tests/CaseStatements.cs
@@ -39,6 +39,25 @@ namespace N {
             }
             return result;
         }
+        public void CommentBranch(string val) {
+            switch (val)
+            {
+                case 'FIRST':{
+                    {
+                        Console.WriteLine("one");
+                    }
+                break;
+                }
+                case 'SECOND':
+                // after colon comment
+                {
+                    {
+                        Console.WriteLine("two");
+                    }
+                break;
+                }
+            }
+        }
     }
     
     public partial class EnumCase {

--- a/tests/CaseStatements.pas
+++ b/tests/CaseStatements.pas
@@ -10,7 +10,8 @@ type
     method SimpleCase(x: Integer);
     method WithElse(x: Integer);
     method Empty(x: Integer);
-    method UpperCase(val: String): String;
+  method UpperCase(val: String): String;
+  method CommentBranch(val: String);
   end;
 
   EnumCase = public class
@@ -58,6 +59,20 @@ begin
   Case val of
     'S': result := 'one';
     'B': result := 'two';
+  end;
+end;
+
+method TTest.CommentBranch(val: String);
+begin
+  case val of
+    'FIRST':
+    begin
+      Console.WriteLine('one');
+    end;
+    'SECOND': // after colon comment
+    begin
+      Console.WriteLine('two');
+    end;
   end;
 end;
 


### PR DESCRIPTION
## Summary
- allow comment lines between a `case` label and its statement
- emit these comments inside the generated C# switch
- update regression test for commented case labels

## Testing
- `pytest -q tests/test_transpile.py::TranspileTests::test_case_statements`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686541cbe194833196ddadc1e3b25828