### PR TITLE
Improve grammar to parse comments between expressions

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -246,6 +246,9 @@ inherited_stmt: INHERITED (name_term ("(" arg_list? ")" call_postfix*)?)? ";"? -
            | "+" expr                                -> pos
            | AT var_ref                              -> addr_of
            | expr expr_comment* OP_SUM expr_comment* expr      -> binop
+           | expr expr_comment+ OP_SUM expr_comment* expr      -> binop
+           | expr expr_comment* op_sum expr_comment* expr      -> binop
+           | expr expr_comment+ op_sum expr_comment* expr      -> binop
            | expr expr_comment* OP_MUL expr_comment* expr      -> binop
            | expr expr_comment* SHL expr_comment* expr         -> binop
            | expr expr_comment* SHR expr_comment* expr         -> binop
@@ -296,6 +299,10 @@ new_expr: "new" type_spec "(" arg_list? ")"         -> new_obj
 
 array_of_expr: "array"i "of"i type_name "(" arg_list? ")" -> array_of_expr
 typeof_expr: TYPEOF "(" expr_comment* expr ")"                        -> typeof_expr
+
+op_sum: "+"      -> plus
+       | "-"      -> minus
+       | OP_SUM
 
 generic_call_base: dotted_name GENERIC_ARGS
 

--- a/tests/ExprComment.cs
+++ b/tests/ExprComment.cs
@@ -6,5 +6,10 @@ namespace Demo {
         public static void CheckStart(int flag1, int flag2) {
             if (flag2 == 2) System.Console.WriteLine("z");
         }
+        public static double SumWithLineComment(double v1, double v2, double v3, double v4) {
+            double result;
+            result = Math.Round(v1 + v2, 2) + Math.Round(v3, 2) + Math.Round(v4, 2);
+            return result;
+        }
     }
 }

--- a/tests/ExprComment.pas
+++ b/tests/ExprComment.pas
@@ -5,6 +5,7 @@ type
   public
     class method Check(flag1: Boolean; flag2: Boolean);
     class method CheckStart(flag1: Integer; flag2: Integer);
+    class method SumWithLineComment(v1, v2, v3, v4: Double): Double;
   end;
 
 implementation
@@ -19,6 +20,14 @@ class method ExprComment.CheckStart(flag1: Integer; flag2: Integer);
 begin
   if ({(flag1 = 1) or} (flag2 = 2)) then
     System.Console.WriteLine('z');
+end;
+
+class method ExprComment.SumWithLineComment(v1, v2, v3, v4: Double): Double;
+begin
+  result := Math.Round(v1 + v2, 2)
+    // extra
+    + Math.Round(v3, 2)
+    + Math.Round(v4, 2);
 end;
 
 end.

--- a/transformer.py
+++ b/transformer.py
@@ -1545,6 +1545,12 @@ class ToCSharp(Transformer):
     def pos(self, expr):
         return f"{expr}"
 
+    def plus(self):
+        return "+"
+
+    def minus(self):
+        return "-"
+
     def number(self, n):
         return str(n).replace("_", "").replace(",", "")
 


### PR DESCRIPTION
## Summary
- handle comments between expression terms
- add coverage in `ExprComment` test for line comments within expressions
- support operator tokens `plus` and `minus`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686559ed7d5c8331a3688fcc30d666d2