### PR TITLE
Support comments after commas in arg lists

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -334,7 +334,7 @@ call_lhs:   var_ref "(" arg_list? ")" call_postfix+                 -> call
            | "(" expr_comment* expr ")" prop_call call_postfix* -> call
            | literal_string "." name_term GENERIC_ARGS? call_args? call_postfix+ -> call
            | typeof_expr call_postfix+                                 -> call
-arg_list:    arg ("," arg)*
+arg_list:    arg ("," expr_comment* arg)* expr_comment*
 arg:         OUT expr                                -> out_arg
            | VAR expr                                -> var_arg
            | CONST expr                              -> const_arg

--- a/pas2cs.py
+++ b/pas2cs.py
@@ -38,7 +38,7 @@ def _get_parser() -> Lark:
     return _PARSER
 
 
-def transpile(source: str, manual_translate=None, manual_parse_error=None, keep_comments: bool = False) -> tuple[str, list[str]]:
+def transpile(source: str, manual_translate=None, manual_parse_error=None) -> tuple[str, list[str]]:
     source = source.lstrip('\ufeff')
     # Collapse accidental double semicolons. For lines that consist solely of a
     # semicolon we strip the semicolon but keep the line break so error
@@ -76,7 +76,7 @@ def transpile(source: str, manual_translate=None, manual_parse_error=None, keep_
             msg = f"Parse error at line {e.line}, column {e.column}:{exp}\n{ctx}"
             raise SyntaxError(msg) from None
         raise
-    gen = ToCSharp(manual_translate=manual_translate, emit_comments=keep_comments)
+    gen = ToCSharp(manual_translate=manual_translate, emit_comments=False)
     body = gen.transform(tree)
     return body, gen.todo
 

--- a/pas2cs.py
+++ b/pas2cs.py
@@ -38,7 +38,7 @@ def _get_parser() -> Lark:
     return _PARSER
 
 
-def transpile(source: str, manual_translate=None, manual_parse_error=None) -> tuple[str, list[str]]:
+def transpile(source: str, manual_translate=None, manual_parse_error=None, keep_comments: bool = False) -> tuple[str, list[str]]:
     source = source.lstrip('\ufeff')
     # Collapse accidental double semicolons. For lines that consist solely of a
     # semicolon we strip the semicolon but keep the line break so error
@@ -76,7 +76,7 @@ def transpile(source: str, manual_translate=None, manual_parse_error=None) -> tu
             msg = f"Parse error at line {e.line}, column {e.column}:{exp}\n{ctx}"
             raise SyntaxError(msg) from None
         raise
-    gen = ToCSharp(manual_translate=manual_translate, emit_comments=False)
+    gen = ToCSharp(manual_translate=manual_translate, emit_comments=keep_comments)
     body = gen.transform(tree)
     return body, gen.todo
 

--- a/tests/ArgListComment.cs
+++ b/tests/ArgListComment.cs
@@ -3,7 +3,7 @@ namespace Demo {
         public static void ThreeArgs(int a, int b, int c) {
         }
         public static void Run() {
-            ThreeArgs(1 // first, 2 // second, 3);
+            ThreeArgs(1 /* first */, 2 /* second */, 3);
         }
     }
 }

--- a/tests/ArgListComment.cs
+++ b/tests/ArgListComment.cs
@@ -3,7 +3,7 @@ namespace Demo {
         public static void ThreeArgs(int a, int b, int c) {
         }
         public static void Run() {
-            ThreeArgs(1, 2, 3);
+            ThreeArgs(1 // first, 2 // second, 3);
         }
     }
 }

--- a/tests/ArgListComment.cs
+++ b/tests/ArgListComment.cs
@@ -1,0 +1,9 @@
+namespace Demo {
+    public partial class ArgListComment {
+        public static void ThreeArgs(int a, int b, int c) {
+        }
+        public static void Run() {
+            ThreeArgs(1, 2, 3);
+        }
+    }
+}

--- a/tests/ArgListComment.pas
+++ b/tests/ArgListComment.pas
@@ -1,0 +1,23 @@
+namespace Demo;
+
+type
+  ArgListComment = public class
+  public
+    class method ThreeArgs(a, b, c: Integer);
+    class method Run;
+  end;
+
+implementation
+
+class method ArgListComment.ThreeArgs(a, b, c: Integer);
+begin
+end;
+
+class method ArgListComment.Run;
+begin
+  ThreeArgs(1, // first
+            2, // second
+            3);
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -831,7 +831,7 @@ class TranspileTests(unittest.TestCase):
     def test_arg_list_comment(self):
         src = Path('tests/ArgListComment.pas').read_text()
         expected = Path('tests/ArgListComment.cs').read_text().strip()
-        result, todos = transpile(src, keep_comments=True)
+        result, todos = transpile(src)
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -831,7 +831,7 @@ class TranspileTests(unittest.TestCase):
     def test_arg_list_comment(self):
         src = Path('tests/ArgListComment.pas').read_text()
         expected = Path('tests/ArgListComment.cs').read_text().strip()
-        result, todos = transpile(src)
+        result, todos = transpile(src, keep_comments=True)
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -828,6 +828,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_arg_list_comment(self):
+        src = Path('tests/ArgListComment.pas').read_text()
+        expected = Path('tests/ArgListComment.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
 
 
     def test_safe_print_cp1252(self):

--- a/transformer.py
+++ b/transformer.py
@@ -662,7 +662,7 @@ class ToCSharp(Transformer):
         return out
 
     def arg_list(self, *args):
-        return list(args)
+        return [a for a in args if a != ""]
 
     def arg(self, value):
         return value


### PR DESCRIPTION
## Summary
- allow optional expression comments after commas in `arg_list`
- filter out blank comment tokens when building argument lists
- add regression test for comments in call argument lists

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865633a9d748331bf1652489e05813f