### PR TITLE
Fix comment handling in variable name lists

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -91,7 +91,7 @@ param_list:  param (";" param)*
 param:       (VAR|OUT|CONST)? name_list ":" type_spec ((OP_REL["="] | ":=") expr)? -> param
             | (VAR|OUT|CONST) name_list ((OP_REL["="] | ":=") expr)? -> param_untyped
 
-name_list:   (CNAME | ENUM | INTERFACE) ("," (CNAME | ENUM | INTERFACE))* -> names
+name_list:   (CNAME | ENUM | INTERFACE) comment* ("," comment* (CNAME | ENUM | INTERFACE) comment*)* -> names
 
 type_spec: type_name "?"?                              -> type_spec
 

--- a/tests/VarNameComments.cs
+++ b/tests/VarNameComments.cs
@@ -1,0 +1,12 @@
+namespace Demo {
+    public partial class VarNameComments {
+        public static void Demo() {
+            string a, // first variable
+                   b, // second variable
+                   c;
+            a = "A";
+            b = "B";
+            c = a + b;
+        }
+    }
+}

--- a/tests/VarNameComments.pas
+++ b/tests/VarNameComments.pas
@@ -1,0 +1,22 @@
+namespace Demo;
+
+type
+  VarNameComments = public class
+  public
+    class method Demo();
+  end;
+
+implementation
+
+class method VarNameComments.Demo();
+var
+  a, // first variable
+  b, // second variable
+  c: String;
+begin
+  a := 'A';
+  b := 'B';
+  c := a + b;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -38,6 +38,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_var_name_comments(self):
+        src = Path('tests/VarNameComments.pas').read_text()
+        expected = Path('tests/VarNameComments.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_comments(self):
         src = Path('tests/Comments.pas').read_text()
         expected = Path('tests/Comments.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -623,7 +623,23 @@ class ToCSharp(Transformer):
         return typ
 
     def names(self, *parts):
-        return [self._safe_name(p) for p in parts]
+        out = []
+        curr = None
+        comments = []
+        for p in parts:
+            text = str(p)
+            if text.startswith("//") or text.startswith("/*") or text.startswith("{") or text.startswith("(*"):
+                comments.append(text)
+                continue
+            if curr is not None:
+                joined = " ".join(comments) if comments else None
+                out.append((self._safe_name(curr), joined))
+                comments = []
+            curr = p
+        if curr is not None:
+            joined = " ".join(comments) if comments else None
+            out.append((self._safe_name(curr), joined))
+        return out
 
     def param(self, *parts):
         # allow optional 'var'/'out' modifier and default value
@@ -641,15 +657,16 @@ class ToCSharp(Transformer):
                 parts.pop(0)
             if parts:
                 default_val = parts.pop(0)
+        name_vals = [n[0] if isinstance(n, tuple) else n for n in names]
         if ptype is None:
             t = "object"
-            info = f"// parameter {', '.join(names)} missing type"
+            info = f"// parameter {', '.join(name_vals)} missing type"
             self.todo.append(info)
         else:
             t = map_type_ext(str(ptype))
         if default_val is not None:
-            return [f"{t} {self._safe_name(n)} = {default_val}" for n in names]
-        return [f"{t} {self._safe_name(n)}" for n in names]
+            return [f"{t} {self._safe_name(n)} = {default_val}" for n in name_vals]
+        return [f"{t} {self._safe_name(n)}" for n in name_vals]
 
     def param_untyped(self, *parts):
         # variant of param rule when no type is declared
@@ -745,22 +762,72 @@ class ToCSharp(Transformer):
         elif len(parts) == 2:
             expr, comment = parts
         t = map_type_ext(str(typ))
-        safe_names = [self._safe_name(n) for n in names]
-        decl = f"{t} {', '.join(safe_names)}"
+        processed = []
+        has_comments = False
+        for n in names:
+            if isinstance(n, tuple):
+                name, cmt = n
+            else:
+                name, cmt = n, None
+            safe = self._safe_name(name)
+            if cmt:
+                has_comments = True
+            processed.append((safe, cmt))
+        if not has_comments:
+            decl = f"{t} {', '.join(name for name, _ in processed)}"
+        else:
+            indent_str = ' ' * (len(t) + 1)
+            parts_lines = []
+            for i, (name, cmt) in enumerate(processed):
+                seg = name
+                if i < len(processed) - 1:
+                    seg += ","
+                if cmt:
+                    seg += " " + cmt
+                if i == 0:
+                    parts_lines.append(seg)
+                else:
+                    parts_lines.append(indent_str + seg)
+            decl = f"{t} " + "\n".join(parts_lines)
         if expr is not None:
             decl += f" = {expr}"
-        for n in safe_names:
-            self.curr_locals.add(str(n))
+        for name, _ in processed:
+            self.curr_locals.add(str(name))
         line = decl + ";"
         if comment:
             line += " " + str(comment)
         return line
 
     def var_decl_infer(self, names, expr, comment=None):
-        safe_names = [self._safe_name(n) for n in names]
-        decl = f"var {', '.join(safe_names)} = {expr}"
-        for n in safe_names:
-            self.curr_locals.add(str(n))
+        processed = []
+        has_comments = False
+        for n in names:
+            if isinstance(n, tuple):
+                name, cmt = n
+            else:
+                name, cmt = n, None
+            safe = self._safe_name(name)
+            if cmt:
+                has_comments = True
+            processed.append((safe, cmt))
+        if not has_comments:
+            decl = f"var {', '.join(name for name, _ in processed)} = {expr}"
+        else:
+            indent_str = ' ' * 4  # len('var ')
+            parts_lines = []
+            for i, (name, cmt) in enumerate(processed):
+                seg = name
+                if i < len(processed) - 1:
+                    seg += ","
+                if cmt:
+                    seg += " " + cmt
+                if i == 0:
+                    parts_lines.append(seg)
+                else:
+                    parts_lines.append(indent_str + seg)
+            decl = "var " + "\n".join(parts_lines) + f" = {expr}"
+        for name, _ in processed:
+            self.curr_locals.add(str(name))
         line = decl + ";"
         if comment:
             line += " " + str(comment)
@@ -793,15 +860,16 @@ class ToCSharp(Transformer):
         else:
             names, typ = items
             expr = None
+        names_only = [n[0] if isinstance(n, tuple) else n for n in names]
         t = map_type_ext(str(typ))
-        info = f"// field {', '.join(names)}: {t} -> declare a field"
+        info = f"// field {', '.join(names_only)}: {t} -> declare a field"
         init = f" = {expr}" if expr is not None else ""
         static_kw = "static " if is_static else ""
-        impl = f"public {static_kw}{t} {', '.join(names)}{init};"
+        impl = f"public {static_kw}{t} {', '.join(names_only)}{init};"
         if self.emit_comments:
             self.todo.append(info)
         if self.curr_class:
-            self.class_fields[self.curr_class].update(names)
+            self.class_fields[self.curr_class].update(names_only)
         if attrs:
             body = "\n".join(attrs + [impl])
         else:


### PR DESCRIPTION
## Summary
- allow comments inside `name_list` grammar rule
- skip comment tokens when collecting variable names
- add new test for variable declarations with inline comments
- preserve inline comments in variable name lists when transpiling

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_var_name_comments -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68656ee69cdc8331b0a41d5d34bc913f