### PR TITLE
Fix comment handling after if keyword

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -206,7 +206,7 @@ with_stmt: WITH expr DO stmt                           -> with_stmt
 yield_stmt: YIELD expr ";"?                           -> yield_stmt
 empty_stmt: ";"                                      -> empty
 comment_stmt: comment                                -> comment_stmt
-if_stmt:     "if"i expr expr_comment* comment_stmt* THEN comment_stmt* (stmt_no_comment comment_stmt* | empty_stmt)? else_clause?        -> if_stmt
+if_stmt:     "if"i expr_comment* expr expr_comment* comment_stmt* THEN comment_stmt* (stmt_no_comment comment_stmt* | empty_stmt)? else_clause?        -> if_stmt
 else_clause: ELSE comment_stmt* stmt_no_comment comment_stmt*                           -> else_clause
            | ELSE comment_stmt*                                -> else_clause_empty
 for_stmt:    "for"i CNAME (":" type_spec)? ":=" expr (TO | DOWNTO) expr (STEP expr)? ("do"i)? stmt  -> for_stmt

--- a/tests/IfExprComment.cs
+++ b/tests/IfExprComment.cs
@@ -9,5 +9,8 @@ namespace Demo {
         public static void CheckMulti(int flag1, int flag2, int flag3) {
             if (flag1 == 1 || flag2 == 2 || flag3 == 3) Console.WriteLine("z");
         }
+        public static void CheckLeading(bool flag) {
+            if (flag) Console.WriteLine("p");
+        }
     }
 }

--- a/tests/IfExprComment.pas
+++ b/tests/IfExprComment.pas
@@ -9,6 +9,7 @@ type
   public
     class method Check(cc: Integer);
     class method CheckMulti(flag1, flag2, flag3: Integer);
+    class method CheckLeading(flag: Boolean);
   end;
 
 implementation
@@ -23,6 +24,12 @@ class method ExprComment.CheckMulti(flag1, flag2, flag3: Integer);
 begin
   if (flag1 = 1) or (flag2 = 2) or (flag3 = 3) { or (flag3 = 4) } then
     Console.WriteLine('z');
+end;
+
+class method ExprComment.CheckLeading(flag: Boolean);
+begin
+  if { prefix } flag then
+    Console.WriteLine('p');
 end;
 
 end.

--- a/transformer.py
+++ b/transformer.py
@@ -1187,7 +1187,13 @@ class ToCSharp(Transformer):
         return ""
 
     def if_stmt(self, cond, *parts):
-        parts = list(parts)
+        parts = [cond, *parts]
+        while parts and parts[0] == "":
+            parts.pop(0)
+        if parts:
+            cond = parts.pop(0)
+        else:
+            cond = ""
         pre_comments = []
         post_comments = []
 


### PR DESCRIPTION
## Summary
- allow comments immediately after `if` keyword
- ignore leading expression comments when generating C#
- test for comment directly after `if`

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_if_expr_comment -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68656e639ae08331a23010203bb6c430