### PR TITLE
Handle comments between if condition lines

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -206,7 +206,7 @@ with_stmt: WITH expr DO stmt                           -> with_stmt
 yield_stmt: YIELD expr ";"?                           -> yield_stmt
 empty_stmt: ";"                                      -> empty
 comment_stmt: comment                                -> comment_stmt
-if_stmt:     "if"i expr expr_comment* comment_stmt* THEN comment_stmt* (stmt_no_comment comment_stmt* | empty_stmt)? else_clause?        -> if_stmt
+if_stmt:     "if"i expr expr_comment* THEN comment_stmt* (stmt_no_comment comment_stmt* | empty_stmt)? else_clause?        -> if_stmt
 else_clause: ELSE comment_stmt* stmt_no_comment comment_stmt*                           -> else_clause
            | ELSE comment_stmt*                                -> else_clause_empty
 for_stmt:    "for"i CNAME (":" type_spec)? ":=" expr (TO | DOWNTO) expr (STEP expr)? ("do"i)? stmt  -> for_stmt

--- a/tests/ExprComment.cs
+++ b/tests/ExprComment.cs
@@ -1,14 +1,14 @@
 namespace Demo {
     public partial class ExprComment {
         public static void Check(bool flag1, bool flag2) {
-            if (flag1 || flag2) System.Console.WriteLine("y");
+            if (flag1 || /* comment */ flag2) System.Console.WriteLine("y");
         }
         public static void CheckStart(int flag1, int flag2) {
-            if (flag2 == 2) System.Console.WriteLine("z");
+            if (/* (flag1 = 1) or */ flag2 == 2) System.Console.WriteLine("z");
         }
         public static double SumWithLineComment(double v1, double v2, double v3, double v4) {
             double result;
-            result = Math.Round(v1 + v2, 2) + Math.Round(v3, 2) + Math.Round(v4, 2);
+            result = Math.Round(v1 + v2, 2) /* extra */ + Math.Round(v3, 2) + Math.Round(v4, 2);
             return result;
         }
     }

--- a/tests/IfExprComment.cs
+++ b/tests/IfExprComment.cs
@@ -3,11 +3,13 @@ using System;
 namespace Demo {
     public partial class ExprComment {
         public static void Check(int cc) {
-            if (cc == 1) /* or cc = 2 */
-            Console.WriteLine("y");
+            if (cc == 1 /* or cc = 2 */) Console.WriteLine("y");
         }
         public static void CheckMulti(int flag1, int flag2, int flag3) {
-            if (flag1 == 1 || flag2 == 2 || flag3 == 3) Console.WriteLine("z");
+            if (flag1 == 1 || flag2 == 2 || flag3 == 3 /* or (flag3 = 4) */) Console.WriteLine("z");
+        }
+        public static void CheckLine(bool flag1, bool flag2) {
+            if (flag1 /* comment */ || flag2) Console.WriteLine("x");
         }
     }
 }

--- a/tests/IfExprComment.pas
+++ b/tests/IfExprComment.pas
@@ -9,6 +9,7 @@ type
   public
     class method Check(cc: Integer);
     class method CheckMulti(flag1, flag2, flag3: Integer);
+    class method CheckLine(flag1, flag2: Boolean);
   end;
 
 implementation
@@ -23,6 +24,13 @@ class method ExprComment.CheckMulti(flag1, flag2, flag3: Integer);
 begin
   if (flag1 = 1) or (flag2 = 2) or (flag3 = 3) { or (flag3 = 4) } then
     Console.WriteLine('z');
+end;
+
+class method ExprComment.CheckLine(flag1, flag2: Boolean);
+begin
+  if (flag1) // comment
+    or (flag2) then
+    Console.WriteLine('x');
 end;
 
 end.


### PR DESCRIPTION
## Summary
- fix grammar to allow inline comments in multi-line if conditions
- ignore empty comment tokens when formatting if statements
- adjust `IfExprComment` tests for new grammar
- preserve comments inside expressions
- convert line comments inside expressions to block comments

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_if_expr_comment -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68656f7b744483318a248c01a9b5922f