### PR TITLE
Allow comments directly after IF

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -206,7 +206,7 @@ with_stmt: WITH expr DO stmt                           -> with_stmt
 yield_stmt: YIELD expr ";"?                           -> yield_stmt
 empty_stmt: ";"                                      -> empty
 comment_stmt: comment                                -> comment_stmt
-if_stmt:     "if"i expr expr_comment* THEN comment_stmt* (stmt_no_comment comment_stmt* | empty_stmt)? else_clause?        -> if_stmt
+if_stmt:     "if"i expr_comment* expr expr_comment* THEN comment_stmt* (stmt_no_comment comment_stmt* | empty_stmt)? else_clause?        -> if_stmt
 else_clause: ELSE comment_stmt* stmt_no_comment comment_stmt*                           -> else_clause
            | ELSE comment_stmt*                                -> else_clause_empty
 for_stmt:    "for"i CNAME (":" type_spec)? ":=" expr (TO | DOWNTO) expr (STEP expr)? ("do"i)? stmt  -> for_stmt

--- a/tests/IfExprComment.cs
+++ b/tests/IfExprComment.cs
@@ -11,8 +11,5 @@ namespace Demo {
         public static void CheckLine(bool flag1, bool flag2) {
             if (flag1 /* comment */ || flag2) Console.WriteLine("x");
         }
-        public static void CheckLeading(bool flag) {
-            if (flag) Console.WriteLine("p");
-        }
     }
 }

--- a/tests/IfLeadingComment.cs
+++ b/tests/IfLeadingComment.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Demo {
+    public partial class IfLeadingComment {
+        public static void Check(bool flag) {
+            if (/* first line
+                   second line */ flag) Console.WriteLine("a");
+        }
+    }
+}

--- a/tests/IfLeadingComment.pas
+++ b/tests/IfLeadingComment.pas
@@ -1,0 +1,22 @@
+namespace Demo;
+
+interface
+
+uses System;
+
+type
+  IfLeadingComment = class
+  public
+    class method Check(flag: Boolean);
+  end;
+
+implementation
+
+class method IfLeadingComment.Check(flag: Boolean);
+begin
+  if { first line
+       second line } flag then
+    Console.WriteLine('a');
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -80,6 +80,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_if_leading_comment(self):
+        src = Path('tests/IfLeadingComment.pas').read_text()
+        expected = Path('tests/IfLeadingComment.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_expr_comment(self):
         src = Path('tests/ExprComment.pas').read_text()
         expected = Path('tests/ExprComment.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -1287,9 +1287,22 @@ class ToCSharp(Transformer):
 
     def if_stmt(self, cond, *parts):
         parts = list(parts)
+        cond_lead = []
         cond_comments = []
         pre_comments = []
         post_comments = []
+
+        if isinstance(cond, str) and (
+            cond.startswith("//") or cond.startswith("/*")
+        ) and parts:
+            rest = ""
+            if cond.startswith("/*") and "*/" in cond:
+                rest = cond.split("*/", 1)[1].strip()
+            elif cond.startswith("//"):
+                rest = cond[2:].strip()
+            if not rest:
+                cond_lead.append(cond)
+                cond = parts.pop(0)
 
         while parts and isinstance(parts[0], str) and not parts[0].strip():
             parts.pop(0)
@@ -1299,8 +1312,8 @@ class ToCSharp(Transformer):
             and (parts[0].startswith("//") or parts[0].startswith("/*"))
         ):
             cond_comments.append(parts.pop(0))
-        if cond_comments:
-            cond = f"{cond} " + " ".join(cond_comments)
+        if cond_lead or cond_comments:
+            cond = " ".join(cond_lead + [str(cond)] + cond_comments)
 
         if parts and isinstance(parts[0], Token):
             parts.pop(0)


### PR DESCRIPTION
## Summary
- update grammar to allow comment tokens before `if` condition expressions
- handle leading comments in `if` statements in the transformer
- fix expected output for `IfExprComment`
- add new regression test `IfLeadingComment`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686581e6007c8331ad8c9c93177f187b