### PR TITLE
Fix case labels with negative values followed by blocks

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -226,7 +226,7 @@ case_stmt:   "case"i expr "of"i case_branch+ case_else? "end"i ";"? -> case_stmt
 case_else:   ELSE stmt+                           -> case_else
            | ELSE ";"?                          -> case_else_empty
 case_branch: comment_stmt* case_label ("," case_label)* ":" comment_stmt* stmt_no_comment ";"?
-signed_number: OP_SUM? NUMBER          -> signed_number
+signed_number: MINUS? NUMBER          -> signed_number
 case_label: signed_number DOTDOT signed_number        -> label_range
           | signed_number
           | SQ_STRING
@@ -356,6 +356,7 @@ GT:           ">"
 GENERIC_ARGS: /<[A-Za-z_][^<>]*(?:<[^<>]*>[^<>]*)*>/
 ASSEMBLY.3:  "assembly"i
 ANDKW.3:     "and"i
+%declare MINUS
 OP_SUM:       "+" | "-" | "or" | "xor"i
 OP_MUL:       "*" | "/" | "and" | "mod"i | "div"i
 OP_REL:       "=" | "<>" | "<=" | ">="

--- a/tests/NegativeCase.cs
+++ b/tests/NegativeCase.cs
@@ -7,5 +7,22 @@ namespace N {
                 case -2: Console.WriteLine("neg two"); break;
             }
         }
+        public void Bar(int x) {
+            switch (x)
+            {
+                case -1:{
+                    {
+                        Console.WriteLine("neg one");
+                    }
+                break;
+                }
+                case -2:{
+                    {
+                        Console.WriteLine("neg two");
+                    }
+                break;
+                }
+            }
+        }
     }
 }

--- a/tests/NegativeCase.pas
+++ b/tests/NegativeCase.pas
@@ -4,6 +4,7 @@ type
   TTest = public class
   public
     method Foo(x: Integer);
+    method Bar(x: Integer);
   end;
 
 implementation
@@ -13,6 +14,20 @@ begin
   case x of
     -1: Console.WriteLine('neg one');
     -2: Console.WriteLine('neg two');
+  end;
+end;
+
+method TTest.Bar(x: Integer);
+begin
+  case x of
+    -1:
+    begin
+      Console.WriteLine('neg one');
+    end;
+    -2:
+    begin
+      Console.WriteLine('neg two');
+    end;
   end;
 end;
 


### PR DESCRIPTION
## Summary
- support negative case labels preceding a block
- add regression test demonstrating the new behaviour

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_negative_case -q`
- `pytest -q` *(fails: test_if_expr_comment)*

------
https://chatgpt.com/codex/tasks/task_e_6865820ed2f0833186aa26d17d138f07