### PR TITLE
Support uses before namespace

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -1,6 +1,6 @@
 # ────────────────────────── Grammar ──────────────────────────
 GRAMMAR = r"""
-?start:   comment* assembly_attr* ns_header uses_clause? (interface_section | pre_class_decl*)? class_section* ("implementation" uses_clause? class_impl*)? (main_block "." | initialization_section? ("end"i ("." | ";"))?)
+?start:   comment* assembly_attr* uses_clause* ns_header uses_clause? (interface_section | pre_class_decl*)? class_section* ("implementation" uses_clause? class_impl*)? (main_block "." | initialization_section? ("end"i ("." | ";"))?)
 main_block: "begin" stmt* "end"i
 interface_section: INTERFACE uses_clause? pre_class_decl*
 

--- a/tests/UsesBeforeNamespace.cs
+++ b/tests/UsesBeforeNamespace.cs
@@ -1,0 +1,10 @@
+using System.Text;
+using System.Collections;
+
+namespace Demo {
+    public partial class UsesBeforeNamespace {
+        public void Foo() {
+        }
+    }
+}
+

--- a/tests/UsesBeforeNamespace.pas
+++ b/tests/UsesBeforeNamespace.pas
@@ -1,0 +1,21 @@
+uses System.Text;
+
+namespace Demo;
+
+interface
+
+uses System.Collections;
+
+type
+  UsesBeforeNamespace = public class
+  public
+    method Foo;
+  end;
+
+implementation
+
+method UsesBeforeNamespace.Foo;
+begin
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -255,6 +255,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_uses_before_namespace(self):
+        src = Path('tests/UsesBeforeNamespace.pas').read_text()
+        expected = Path('tests/UsesBeforeNamespace.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_ctor_impl_no_name(self):
         src = Path('tests/CtorImplNoName.pas').read_text()
         expected = Path('tests/CtorImplNoName.cs').read_text().strip()


### PR DESCRIPTION
## Summary
- relax grammar to accept `uses` clauses before a `namespace`
- add test coverage for a unit that has a `uses` clause before the namespace header

## Testing
- `pip install lark-parser`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68658647fb6c8331b3c37fed7aaa4c90