### PR TITLE
Allow comments between case branches

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -225,7 +225,7 @@ on_handler_type: ON type_name DO stmt -> on_handler_type
 case_stmt:   "case"i expr "of"i case_branch+ case_else? "end"i ";"? -> case_stmt
 case_else:   ELSE stmt+                           -> case_else
            | ELSE ";"?                          -> case_else_empty
-case_branch: comment_stmt* case_label ("," case_label)* ":" comment_stmt* stmt_no_comment ";"?
+case_branch: comment_stmt* case_label ("," case_label)* ":" comment_stmt* stmt_no_comment comment_stmt* ";"?
 signed_number: OP_SUM? NUMBER          -> signed_number
 case_label: signed_number DOTDOT signed_number        -> label_range
           | signed_number

--- a/tests/CaseComment.cs
+++ b/tests/CaseComment.cs
@@ -11,6 +11,15 @@ namespace Demo {
                 case 'B': Console.WriteLine("b"); break;
             }
         }
+        public void CommentedBranch(char val) {
+            switch (val)
+            {
+                case 'A': Console.WriteLine("a"); break;
+                //    'B':
+                //      Console.WriteLine('b');
+                case 'C': Console.WriteLine("c"); break;
+            }
+        }
     }
 }
 

--- a/tests/CaseComment.pas
+++ b/tests/CaseComment.pas
@@ -6,6 +6,7 @@ type
   CaseComment = public class
   public
     method Test(val: Char);
+    method CommentedBranch(val: Char);
   end;
 
 implementation
@@ -17,6 +18,16 @@ begin
     'A': Console.WriteLine('a');
     //B
     'B': Console.WriteLine('b');
+  end;
+end;
+
+method CaseComment.CommentedBranch(val: Char);
+begin
+  case val of
+    'A': Console.WriteLine('a');
+//    'B':
+//      Console.WriteLine('b');
+    'C': Console.WriteLine('c');
   end;
 end;
 

--- a/transformer.py
+++ b/transformer.py
@@ -1544,46 +1544,42 @@ class ToCSharp(Transformer):
         return res
 
     def case_stmt(self, expr, *parts):
-        branches = [p for p in parts if isinstance(p, tuple) and p[0] == "branch"]
-        else_branch = [
-            p for p in parts if not (isinstance(p, tuple) and p[0] == "branch")
-        ]
-        else_branch = [
-            p for p in else_branch if not (isinstance(p, Token) and p.type == "ELSE")
-        ]
-        flat_else = []
-        for eb in else_branch:
-            if isinstance(eb, list):
-                flat_else.extend(eb)
-            else:
-                flat_else.append(eb)
-        else_branch = flat_else
+        parts = list(parts)
+        else_branch = []
+        if parts and isinstance(parts[-1], list):
+            else_branch = parts.pop()
 
         switch_body = []
-        for _tag, labels, pre_comments, post_comments, stmt in branches:
-            patterns = []
-            for label in labels:
-                if isinstance(label, tuple) and label[0] == "range":
-                    start, end = label[1], label[2]
-                    patterns.append(f">= {start} and <= {end}")
-                else:
-                    patterns.append(str(label))
-            for c in pre_comments:
-                switch_body.append(c)
-            case_line = "case " + " or ".join(patterns) + ":"
-            is_multiline = "\n" in stmt or not stmt.strip().endswith(";")
-            if is_multiline:
-                body = f"{{\n{indent(stmt)}\nbreak;\n}}"
-            else:
-                body = f" {stmt} break;"
-
-            if not post_comments and (not is_multiline or body.startswith("{")):
-                switch_body.append(case_line + body)
-            else:
-                switch_body.append(case_line)
-                for c in post_comments:
+        for part in parts:
+            if isinstance(part, tuple) and part[0] == "branch":
+                _tag, labels, pre_comments, post_comments, trailing, stmt = part
+                patterns = []
+                for label in labels:
+                    if isinstance(label, tuple) and label[0] == "range":
+                        start, end = label[1], label[2]
+                        patterns.append(f">= {start} and <= {end}")
+                    else:
+                        patterns.append(str(label))
+                for c in pre_comments:
                     switch_body.append(c)
-                switch_body.append(body)
+                case_line = "case " + " or ".join(patterns) + ":"
+                is_multiline = "\n" in stmt or not stmt.strip().endswith(";")
+                if is_multiline:
+                    body = f"{{\n{indent(stmt)}\nbreak;\n}}"
+                else:
+                    body = f" {stmt} break;"
+
+                if not post_comments and (not is_multiline or body.startswith("{")):
+                    switch_body.append(case_line + body)
+                else:
+                    switch_body.append(case_line)
+                    for c in post_comments:
+                        switch_body.append(c)
+                    switch_body.append(body)
+                for c in trailing:
+                    switch_body.append(c)
+            elif isinstance(part, str):
+                switch_body.append(part)
 
         if else_branch:
             else_stmts = "\n".join(s for s in else_branch if s.strip())
@@ -1596,12 +1592,29 @@ class ToCSharp(Transformer):
         return f"switch ({expr})\n{{\n{body_cs}\n}}"
 
     def case_branch(self, *parts):
-        stmt = parts[-1]
+        parts = list(parts)
+        if parts and isinstance(parts[-1], Token) and str(parts[-1]) == ";":
+            parts.pop()
+
+        trailing_comments = []
+        def _is_comment(s):
+            s = s.strip()
+            if s.startswith("//") or s.startswith("/*") or s.startswith("(*"):
+                return True
+            if s.startswith("{") and s.endswith("}") and "\n" not in s:
+                return True
+            return False
+
+        while parts and isinstance(parts[-1], str) and _is_comment(parts[-1]):
+            trailing_comments.insert(0, parts.pop())
+
+        stmt = parts.pop()
+
         pre_comments = []
         post_comments = []
         labels = []
         seen_label = False
-        for p in parts[:-1]:
+        for p in parts:
             if isinstance(p, str) and p.strip().startswith(("//", "/*", "{", "(*")):
                 if seen_label:
                     post_comments.append(p)
@@ -1610,7 +1623,8 @@ class ToCSharp(Transformer):
             else:
                 labels.append(p)
                 seen_label = True
-        return ("branch", labels, pre_comments, post_comments, stmt)
+
+        return ("branch", labels, pre_comments, post_comments, trailing_comments, stmt)
 
     def case_label(self, tok):
         if isinstance(tok, Token):


### PR DESCRIPTION
## Summary
- handle comments placed between case branches
- update the `CaseComment` example to include a commented-out branch
- adjust expected C# output

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_case_comment -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686586c023c88331beecef08913ced1c