### PR TITLE
Support leading comments in assignments

### DIFF
--- a/grammar.py
+++ b/grammar.py
@@ -189,9 +189,9 @@ block:       "begin" ";"? stmt* "end"i comment* ";"?
 
            
 
-assign_stmt: (inherited_var | var_ref | call_lhs) ":=" expr (";" comment?)? -> assign
-op_assign_stmt: (var_ref | call_lhs) ADD_ASSIGN expr (";" comment?)?              -> op_assign
-              | (var_ref | call_lhs) SUB_ASSIGN expr (";" comment?)?              -> op_assign
+assign_stmt: (inherited_var | var_ref | call_lhs) ":=" expr_comment* expr (";" comment?)? -> assign
+op_assign_stmt: (var_ref | call_lhs) ADD_ASSIGN expr_comment* expr (";" comment?)?              -> op_assign
+              | (var_ref | call_lhs) SUB_ASSIGN expr_comment* expr (";" comment?)?              -> op_assign
 return_stmt: RESULT ":=" expr (";" comment?)?             -> result_ret
            | EXIT expr? (";" comment?)?                            -> exit_ret
 raise_stmt: RAISE expr? (";" comment?)?                           -> raise_stmt

--- a/tests/AssignLeadingComment.cs
+++ b/tests/AssignLeadingComment.cs
@@ -1,0 +1,11 @@
+namespace Demo {
+    public partial class AssignLeadingComment {
+        public static int Demo() {
+            int result;
+            int v;
+            v = /* leading comment */ 5;
+            result = v;
+            return result;
+        }
+    }
+}

--- a/tests/AssignLeadingComment.pas
+++ b/tests/AssignLeadingComment.pas
@@ -1,0 +1,19 @@
+namespace Demo;
+
+type
+  AssignLeadingComment = class
+  public
+    class method Demo: Integer;
+  end;
+
+implementation
+
+class method AssignLeadingComment.Demo: Integer;
+var
+  v: Integer;
+begin
+  v := { leading comment } 5;
+  result := v;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -38,6 +38,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_assign_leading_comment(self):
+        src = Path('tests/AssignLeadingComment.pas').read_text()
+        expected = Path('tests/AssignLeadingComment.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_comments(self):
         src = Path('tests/Comments.pas').read_text()
         expected = Path('tests/Comments.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -1179,13 +1179,29 @@ class ToCSharp(Transformer):
         return (cls, name, ", ".join(param_list), self.curr_rettype)
 
     # ── statements ──────────────────────────────────────────
-    def assign(self, var, expr, comment=None):
+    def assign(self, var, *parts):
+        comment = None
+        if parts and isinstance(parts[-1], str) and parts[-1].startswith("/*"):
+            comment = parts[-1]
+            parts = parts[:-1]
+        expr = parts[-1]
+        lead = [p for p in parts[:-1] if p]
+        if lead:
+            expr = " ".join(lead + [str(expr)])
         line = f"{var} = {expr};"
         if comment:
             line += " " + str(comment)
         return line
 
-    def op_assign(self, var, op, expr, comment=None):
+    def op_assign(self, var, op, *parts):
+        comment = None
+        if parts and isinstance(parts[-1], str) and parts[-1].startswith("/*"):
+            comment = parts[-1]
+            parts = parts[:-1]
+        expr = parts[-1]
+        lead = [p for p in parts[:-1] if p]
+        if lead:
+            expr = " ".join(lead + [str(expr)])
         line = f"{var} {op} {expr};"
         if comment:
             line += " " + str(comment)


### PR DESCRIPTION
## Summary
- allow comment tokens immediately after `:=`, `+=`, and `-=` in grammar
- handle leading comments in `assign` and `op_assign` transformer rules
- add regression test for assignment with comment before the expression

## Testing
- `pytest -q tests/test_transpile.py::TranspileTests::test_assign_leading_comment`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866629137d88331b95283bb3385a6a6