### PR TITLE
Preserve Pascal region directives

### DIFF
--- a/tests/Comments.cs
+++ b/tests/Comments.cs
@@ -10,6 +10,8 @@ namespace Demo {
     }
     
     public partial class Foo {
+        #region extra
+        #endregion
         public int ValueParen() {
             int result;
             /* comment with *** inside

--- a/transformer.py
+++ b/transformer.py
@@ -80,8 +80,14 @@ class ToCSharp(Transformer):
         if text.startswith("{") and text.endswith("}"):
             inner = text[1:-1].strip()
             lowered = inner.lower()
-            if lowered.startswith("$region") or lowered.startswith("$endregion"):
-                return ""
+            if lowered.startswith("$region"):
+                title = inner[len("$region"):].strip()
+                if (title.startswith("'") and title.endswith("'")) or (
+                    title.startswith('"') and title.endswith('"')):
+                    title = title[1:-1]
+                return "#region " + title
+            if lowered.startswith("$endregion"):
+                return "#endregion"
             if lowered.startswith("region"):
                 return "#region " + inner[6:].strip()
             if lowered.startswith("endregion"):


### PR DESCRIPTION
## Summary
- preserve `{$REGION}` directives when transpiling
- expect region markers in `Comments.cs`

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_comments -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866669ff1f08331ab7e1b3280612b09