### PR TITLE
Fix region comments within implementation blocks

### DIFF
--- a/tests/RegionImpl.cs
+++ b/tests/RegionImpl.cs
@@ -1,0 +1,8 @@
+namespace Demo {
+    public partial class Example {
+        #region impl
+        public void Foo() {
+        }
+        #endregion
+    }
+}

--- a/tests/RegionImpl.pas
+++ b/tests/RegionImpl.pas
@@ -1,0 +1,19 @@
+namespace Demo;
+
+interface
+
+type
+  Example = class
+  public
+    procedure Foo;
+  end;
+
+implementation
+
+{$REGION 'impl'}
+procedure Example.Foo;
+begin
+end;
+{$ENDREGION}
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -870,6 +870,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_region_impl(self):
+        src = Path('tests/RegionImpl.pas').read_text()
+        expected = Path('tests/RegionImpl.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
 
 
     def test_safe_print_cp1252(self):


### PR DESCRIPTION
## Summary
- preserve `{$REGION}` directives found in implementation parts
- capture pending comments and output them before methods
- add regression test covering regions in implementation

## Testing
- `pytest -q tests/test_transpile.py::TranspileTests::test_region_impl`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686675d7ffb48331835ed4d9c0c1bb79