### PR TITLE
Handle unclosed region blocks

### DIFF
--- a/tests/RegionBlock.cs
+++ b/tests/RegionBlock.cs
@@ -1,0 +1,10 @@
+namespace Demo {
+    public partial class Foo {
+        #region Impl
+        public void A() {
+        }
+        public void B() {
+        }
+        #endregion
+    }
+}

--- a/tests/RegionBlock.pas
+++ b/tests/RegionBlock.pas
@@ -1,0 +1,24 @@
+namespace Demo;
+
+interface
+
+type
+  Foo = class
+  public
+    method A();
+    method B();
+  end;
+
+implementation
+
+{$REGION 'Impl'}
+method Foo.A;
+begin
+end;
+
+method Foo.B;
+begin
+end;
+{$ENDREGION}
+
+end.

--- a/tests/RegionUnclosed.cs
+++ b/tests/RegionUnclosed.cs
@@ -1,0 +1,8 @@
+namespace Demo {
+    public partial class Foo {
+        #region Impl
+        public void A() {
+        }
+        #endregion
+    }
+}

--- a/tests/RegionUnclosed.pas
+++ b/tests/RegionUnclosed.pas
@@ -1,0 +1,18 @@
+namespace Demo;
+
+interface
+
+type
+  Foo = class
+  public
+    method A();
+  end;
+
+implementation
+
+{$REGION 'Impl'}
+method Foo.A;
+begin
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -52,6 +52,20 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_region_block(self):
+        src = Path('tests/RegionBlock.pas').read_text()
+        expected = Path('tests/RegionBlock.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
+    def test_region_unclosed(self):
+        src = Path('tests/RegionUnclosed.pas').read_text()
+        expected = Path('tests/RegionUnclosed.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_line_comment(self):
         src = Path('tests/LineComment.pas').read_text()
         expected = Path('tests/LineComment.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -45,6 +45,20 @@ class ToCSharp(Transformer):
         self.class_attributes = defaultdict(list)
         self.in_attribute = False
         self.pending_class_comments = []
+        self.pending_impl_comments = []
+        self.last_impl_class = None
+
+    def _close_open_regions(self, lines):
+        stack = []
+        for item in lines:
+            for line in str(item).split('\n'):
+                s = line.strip()
+                if s.startswith('#region'):
+                    stack.append('#endregion')
+                elif s.startswith('#endregion') and stack:
+                    stack.pop()
+        lines.extend(stack)
+        return lines
 
     def _append_comment(self, line: str, comment: str) -> str:
         """Append comment to a line, placing region directives on their own line."""
@@ -189,6 +203,10 @@ class ToCSharp(Transformer):
 
     # ── root rule -------------------------------------------------
     def start(self, *parts):
+        if self.pending_impl_comments and self.last_impl_class:
+            for c in self.pending_impl_comments:
+                self.class_impls[self.last_impl_class].append((None, c))
+            self.pending_impl_comments = []
         classes = []
         first_class = True
         for cname in self.class_order:
@@ -231,6 +249,7 @@ class ToCSharp(Transformer):
                     body_lines.append(reg[1])
                 else:
                     body_lines.append(method)
+            body_lines = self._close_open_regions(body_lines)
             body = "\n".join(body_lines).rstrip()
             body = indent(body) if body else ""
             attrs = self.class_attributes.get(cname, [])
@@ -274,6 +293,9 @@ class ToCSharp(Transformer):
             ns_items.extend(self.delegate_defs)
         ns_items.extend(classes)
         ns_body = "\n\n".join(ns_items)
+        ns_body_lines = ns_body.split('\n') if ns_body else []
+        ns_body_lines = self._close_open_regions(ns_body_lines)
+        ns_body = "\n".join(ns_body_lines)
         using_lines = ""
         if self.usings:
             using_lines = "\n".join(f"using {u};" for u in self.usings.keys())
@@ -327,20 +349,23 @@ class ToCSharp(Transformer):
         return (name.strip(), params.strip(), ret.strip(), static_flag)
 
     def class_impl(self, *parts):
-        attrs = []
-        if parts and isinstance(parts[0], list):
-            attrs = parts[0]
-            parts = parts[1:]
-        # last element is the processed method implementation (ignored)
-        if attrs and self.curr_impl_class:
-            methods = self.class_impls.get(self.curr_impl_class, [])
-            if methods:
-                key, method = methods.pop()
-                method = "\n".join(attrs) + "\n" + method
-                methods.append((key, method))
-                self.class_impls[self.curr_impl_class] = methods
-                if self.curr_impl_key is not None:
-                    self.impl_map[self.curr_impl_class][self.curr_impl_key] = method
+        if len(parts) == 1 and isinstance(parts[0], str):
+            self.pending_impl_comments.append(parts[0])
+        else:
+            attrs = []
+            if parts and isinstance(parts[0], list):
+                attrs = parts[0]
+                parts = parts[1:]
+            # last element is the processed method implementation (ignored)
+            if attrs and self.curr_impl_class:
+                methods = self.class_impls.get(self.curr_impl_class, [])
+                if methods:
+                    key, method = methods.pop()
+                    method = "\n".join(attrs) + "\n" + method
+                    methods.append((key, method))
+                    self.class_impls[self.curr_impl_class] = methods
+                    if self.curr_impl_key is not None:
+                        self.impl_map[self.curr_impl_class][self.curr_impl_key] = method
         self.curr_impl_class = None
         self.curr_impl_key = None
         return ""
@@ -1172,10 +1197,15 @@ class ToCSharp(Transformer):
             attrs_all.extend(attrs)
         if attrs_all:
             method = "\n".join(attrs_all) + "\n" + method
+        if self.pending_impl_comments:
+            for c in self.pending_impl_comments:
+                self.class_impls[cls].append((None, c))
+            self.pending_impl_comments = []
         self.class_impls[cls].append((key, method))
         self.impl_methods[cls].add(key)
         self.impl_map[cls][key] = method
         self.curr_impl_key = key
+        self.last_impl_class = cls
         # clear method context after generating its body (except curr_impl_class)
         self.curr_method = None
         self.curr_params = []


### PR DESCRIPTION
## Summary
- close unmatched regions when building class or namespace bodies
- new test for an unclosed region block

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_region_unclosed -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686675d7ffb48331835ed4d9c0c1bb79