### PR TITLE
Fix region directive after if-statement

### DIFF
--- a/tests/RegionStmt.cs
+++ b/tests/RegionStmt.cs
@@ -1,0 +1,11 @@
+namespace Demo {
+    public partial class Foo {
+        public void Test() {
+            #region inner
+            if (!isPostBack) {
+                DoIt();
+            }
+            #endregion
+        }
+    }
+}

--- a/tests/RegionStmt.pas
+++ b/tests/RegionStmt.pas
@@ -1,0 +1,23 @@
+namespace Demo;
+
+interface
+
+type
+  Foo = class
+  public
+    method Test;
+  end;
+
+implementation
+
+method Foo.Test;
+begin
+  {$REGION 'inner'}
+  if not isPostBack then
+  begin
+    DoIt();
+  end;
+  {$ENDREGION}
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -73,6 +73,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_region_stmt(self):
+        src = Path('tests/RegionStmt.pas').read_text()
+        expected = Path('tests/RegionStmt.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_line_comment(self):
         src = Path('tests/LineComment.pas').read_text()
         expected = Path('tests/LineComment.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -1454,7 +1454,10 @@ class ToCSharp(Transformer):
         post_comments = []
 
         if isinstance(cond, str) and (
-            cond.startswith("//") or cond.startswith("/*")
+            cond.startswith("//")
+            or cond.startswith("/*")
+            or cond.startswith("#region")
+            or cond.startswith("#endregion")
         ) and parts:
             rest = ""
             if cond.startswith("/*") and "*/" in cond:
@@ -1470,7 +1473,12 @@ class ToCSharp(Transformer):
         while (
             parts
             and isinstance(parts[0], str)
-            and (parts[0].startswith("//") or parts[0].startswith("/*"))
+            and (
+                parts[0].startswith("//")
+                or parts[0].startswith("/*")
+                or parts[0].startswith("#region")
+                or parts[0].startswith("#endregion")
+            )
         ):
             cond_comments.append(parts.pop(0))
         if cond_lead or cond_comments:
@@ -1484,7 +1492,12 @@ class ToCSharp(Transformer):
         while (
             parts
             and isinstance(parts[0], str)
-            and (parts[0].startswith("//") or parts[0].startswith("/*"))
+            and (
+                parts[0].startswith("//")
+                or parts[0].startswith("/*")
+                or parts[0].startswith("#region")
+                or parts[0].startswith("#endregion")
+            )
         ):
             pre_comments.append(parts.pop(0))
 
@@ -1495,7 +1508,12 @@ class ToCSharp(Transformer):
         while (
             parts
             and isinstance(parts[0], str)
-            and (parts[0].startswith("//") or parts[0].startswith("/*"))
+            and (
+                parts[0].startswith("//")
+                or parts[0].startswith("/*")
+                or parts[0].startswith("#region")
+                or parts[0].startswith("#endregion")
+            )
         ):
             post_comments.append(parts.pop(0))
 
@@ -1528,7 +1546,12 @@ class ToCSharp(Transformer):
         comment_text = None
         if else_clause is not None:
             text = str(else_clause).strip()
-            if text and (text.startswith("//") or text.startswith("/*")):
+            if text and (
+                text.startswith("//")
+                or text.startswith("/*")
+                or text.startswith("#region")
+                or text.startswith("#endregion")
+            ):
                 comment_only = True
                 comment_text = text
 


### PR DESCRIPTION
## Summary
- handle `#region`/`#endregion` as comments in `if` statement parsing
- add regression test for region directives following an `if` block

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_region_stmt -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866972ae1d08331822358438a59c410