### PR TITLE
Fix escaping of reserved keywords in property calls

### DIFF
--- a/tests/PropertyAssign.cs
+++ b/tests/PropertyAssign.cs
@@ -5,7 +5,7 @@ namespace Demo {
             nvc.Add("texto", this.pMensagem.Trim);
             gMeta.Visible = perm.numeroRegistros > 0;
             CustomValidator(source).ErrorMessage = "Selecione um funcionario";
-            CheckBox(e.Item.Cells[3].controls[0]).checked = (string)ds.Tables[0].DefaultView.Item[e.Item.ItemIndex]["IND_TRAMITACAO"] == "S";
+            CheckBox(e.Item.Cells[3].controls[0]).@checked = (string)ds.Tables[0].DefaultView.Item[e.Item.ItemIndex]["IND_TRAMITACAO"] == "S";
         }
     }
     

--- a/tests/ReservedAfterCall.cs
+++ b/tests/ReservedAfterCall.cs
@@ -1,0 +1,9 @@
+using System.Windows.Forms;
+
+namespace Demo {
+    public partial class Caller {
+        public void SetState(CheckBox cb) {
+            CheckBox(cb).@checked = true;
+        }
+    }
+}

--- a/tests/ReservedAfterCall.pas
+++ b/tests/ReservedAfterCall.pas
@@ -1,0 +1,17 @@
+namespace Demo;
+
+type
+  Caller = public class
+  public
+    method SetState(cb: CheckBox);
+  end;
+
+implementation
+uses System.Windows.Forms;
+
+method Caller.SetState(cb: CheckBox);
+begin
+  CheckBox(cb).checked := true;
+end;
+
+end.

--- a/tests/test_transpile.py
+++ b/tests/test_transpile.py
@@ -636,6 +636,13 @@ class TranspileTests(unittest.TestCase):
         self.assertEqual(result.strip(), expected)
         self.assertEqual(todos, [])
 
+    def test_reserved_after_call(self):
+        src = Path('tests/ReservedAfterCall.pas').read_text()
+        expected = Path('tests/ReservedAfterCall.cs').read_text().strip()
+        result, todos = transpile(src)
+        self.assertEqual(result.strip(), expected)
+        self.assertEqual(todos, [])
+
     def test_keyword_name(self):
         src = Path('tests/KeywordName.pas').read_text()
         expected = Path('tests/KeywordName.cs').read_text().strip()

--- a/transformer.py
+++ b/transformer.py
@@ -2073,14 +2073,15 @@ class ToCSharp(Transformer):
                 kind = part[0]
                 if kind == "prop":
                     name, args = part[1], part[2]
+                    safe_name = self._safe_name(name)
                     if args is None:
-                        call += f".{name}"
+                        call += f".{safe_name}"
                     else:
                         args = [
                             a[2] if isinstance(a, tuple) and a[0] == "named" else a
                             for a in args
                         ]
-                        call += f".{name}({', '.join(args)})"
+                        call += f".{safe_name}({', '.join(args)})"
                 elif kind == "index":
                     call += part[1]
             elif isinstance(part, Token) and part.type == "GENERIC_ARGS":


### PR DESCRIPTION
## Summary
- ensure property calls escape C# keywords
- add regression test for property access after a call
- adjust PropertyAssign output

## Testing
- `pytest tests/test_transpile.py::TranspileTests::test_reserved_after_call -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866a513555c83318fcf80d83594a3a4