### PR TITLE
Improve CaseFixer and add unit test

### DIFF
--- a/CaseFixer.Tests/CaseFixer.Tests.csproj
+++ b/CaseFixer.Tests/CaseFixer.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../CaseFixer.csproj" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" />
+  </ItemGroup>
+</Project>

--- a/CaseFixer.Tests/CaseFixerTests.cs
+++ b/CaseFixer.Tests/CaseFixerTests.cs
@@ -1,0 +1,73 @@
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CaseFixer.Tests;
+
+public class CaseFixerTests
+{
+    [Fact]
+    public async Task AddsParenthesesToMethodCall()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var file = Path.Combine(tempDir, "Demo.cs");
+            File.WriteAllText(file, @"class Demo {
+    int Foo() { return 1; }
+    void Bar() {
+        var x = foo;
+    }
+}");
+
+            using var server = new OmniSharpStub(file);
+            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1" });
+            Assert.Equal(0, exitCode);
+
+            string result = File.ReadAllText(file);
+            Assert.Contains("Foo()", result);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
+    public async Task ProcessesMultipleFiles()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        try
+        {
+            var file1 = Path.Combine(tempDir, "Demo.cs");
+            var file2 = Path.Combine(tempDir, "DemoOther.cs");
+
+            File.WriteAllText(file1, @"class Demo {
+    int Foo() { return 1; }
+}");
+
+            File.WriteAllText(file2, @"class DemoOther {
+    void Bar() {
+        var d = new Demo();
+        var x = d.foo;
+    }
+}");
+
+            using var server = new OmniSharpStub(file1);
+            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1" });
+            Assert.Equal(0, exitCode);
+
+            string result1 = File.ReadAllText(file1);
+            string result2 = File.ReadAllText(file2);
+            Assert.Contains("Foo()", result2);
+            Assert.Equal("class Demo {\n    int Foo() { return 1; }\n}", result1.Replace("\r", ""));
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+}

--- a/CaseFixer.Tests/OmniSharpStub.cs
+++ b/CaseFixer.Tests/OmniSharpStub.cs
@@ -1,0 +1,69 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace CaseFixer.Tests;
+
+internal sealed class OmniSharpStub : IDisposable
+{
+    private readonly HttpListener _listener = new();
+    private readonly Task _loop;
+    private readonly string _filePath;
+
+    public OmniSharpStub(string filePath)
+    {
+        _filePath = filePath;
+        _listener.Prefixes.Add("http://localhost:2000/");
+        _listener.Start();
+        _loop = Task.Run(LoopAsync);
+    }
+
+    private async Task LoopAsync()
+    {
+        while (_listener.IsListening)
+        {
+            var ctx = await _listener.GetContextAsync();
+            if (ctx.Request.HttpMethod == "POST" && ctx.Request.Url.AbsolutePath == "/v2/gotoDefinition")
+            {
+                using var reader = new StreamReader(ctx.Request.InputStream);
+                var body = await reader.ReadToEndAsync();
+                var resp = new
+                {
+                    definitions = new[]
+                    {
+                        new
+                        {
+                            FileName = _filePath,
+                            Range = new
+                            {
+                                Start = new { Line = 2, Column = 9 },
+                                End = new { Line = 2, Column = 12 }
+                            }
+                        }
+                    }
+                };
+                var json = JsonSerializer.Serialize(resp);
+                var bytes = Encoding.UTF8.GetBytes(json);
+                ctx.Response.StatusCode = 200;
+                ctx.Response.ContentType = "application/json";
+                await ctx.Response.OutputStream.WriteAsync(bytes, 0, bytes.Length);
+                ctx.Response.Close();
+            }
+            else
+            {
+                ctx.Response.StatusCode = 404;
+                ctx.Response.Close();
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        _listener.Stop();
+        _listener.Close();
+        try { _loop.Wait(1000); } catch { }
+    }
+}

--- a/CaseFixer.cs
+++ b/CaseFixer.cs
@@ -1,0 +1,207 @@
+// ------------------------------------------------------------
+// CaseFixer.cs – post-transpilation case-repair tool
+// ------------------------------------------------------------
+// Build:  dotnet build -c Release
+// Run:    CaseFixer <solution-root> [--backup] [--threads N] [--verbose]
+// Requires an OmniSharp instance listening on http://localhost:2000
+// ------------------------------------------------------------
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Text.Json.Serialization;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+[assembly: InternalsVisibleTo("CaseFixer.Tests")]
+
+namespace CaseFixer;
+
+/// <summary>
+/// Walks *.cs files produced by an Oxygene->C# transpiler and fixes
+/// identifier casing mismatches by querying OmniSharp (Roslyn).
+/// </summary>
+internal static class Program
+{
+    private static readonly HttpClient Http = new() { BaseAddress = new("http://localhost:2000/") };
+
+    // Cache to avoid hitting OmniSharp repeatedly for the same symbol
+    private static readonly ConcurrentDictionary<string, string> CanonicalCaseCache =
+        new(StringComparer.OrdinalIgnoreCase);
+
+    internal delegate Task<(string? Name, bool IsParameterless)> SymbolResolver(string filePath, SyntaxTree tree, SyntaxToken token);
+
+    internal static SymbolResolver ResolveSymbol = GetSymbolInfoAsync;
+
+    public static async Task<int> Main(string[] args)
+    {
+        if (args.Length == 0 || args[0] is "-h" or "--help")
+        {
+            Console.WriteLine("Usage: CaseFixer <root-directory> [--backup] [--threads N] [--verbose]");
+            return 1;
+        }
+
+        var root = Path.GetFullPath(args[0]);
+        bool backup = args.Contains("--backup");
+        bool verbose = args.Contains("--verbose");
+        int threads = args.SkipWhile(a => a != "--threads").Skip(1).Select(int.Parse).FirstOrDefault(Environment.ProcessorCount);
+
+        if (!Directory.Exists(root))
+        {
+            Console.Error.WriteLine($"Directory not found: {root}");
+            return 2;
+        }
+
+        var files = Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories)
+                             .Where(f => !f.EndsWith(".Designer.cs", StringComparison.OrdinalIgnoreCase))
+                             .ToList();
+
+        var sem = new SemaphoreSlim(threads);
+        var tasks = files.Select(path => ProcessFileAsync(path, backup, verbose, sem));
+        var counts = await Task.WhenAll(tasks);
+        var totalFixed = counts.Sum();
+
+        Console.WriteLine($"\n\u2714 Done – processed {files.Count} file(s), fixed {totalFixed} identifier(s).\n");
+        return 0;
+    }
+
+    internal static async Task<(string Result, int Fixed)> FixSourceAsync(string source, string filePath, SymbolResolver resolver)
+    {
+        var tree = CSharpSyntaxTree.ParseText(source);
+        var root = tree.GetRoot();
+
+        var edits = new List<(int start, int length, string replacement)>();
+
+        foreach (var token in root.DescendantTokens().Where(t => t.IsKind(SyntaxKind.IdentifierToken)))
+        {
+            var original = token.ValueText;
+            if (string.IsNullOrWhiteSpace(original)) continue;
+
+            if (CanonicalCaseCache.TryGetValue(original, out var cached))
+            {
+                if (!string.Equals(original, cached, StringComparison.Ordinal))
+                    edits.Add((token.SpanStart, token.Span.Length, cached));
+                continue;
+            }
+
+            var (symbolName, isMethod) = await resolver(filePath, tree, token);
+            if (symbolName is null && !isMethod) continue;
+
+            if (symbolName is not null)
+            {
+                CanonicalCaseCache.TryAdd(original, symbolName);
+                if (!string.Equals(original, symbolName, StringComparison.Ordinal))
+                    edits.Add((token.SpanStart, token.Span.Length, symbolName));
+            }
+
+            if (isMethod && token.Parent is IdentifierNameSyntax name)
+            {
+                bool alreadyCall = name.Parent is InvocationExpressionSyntax inv && inv.Expression == name;
+                if (!alreadyCall && name.Parent is MemberAccessExpressionSyntax mem && mem.Name == name && mem.Parent is InvocationExpressionSyntax inv2 && inv2.Expression == mem)
+                    alreadyCall = true;
+
+                if (!alreadyCall)
+                    edits.Add((token.SpanStart + token.Span.Length, 0, "()"));
+            }
+        }
+
+        if (edits.Count == 0) return (source, 0);
+
+        var sb = new StringBuilder(source);
+        foreach (var (start, length, replacement) in edits.OrderByDescending(e => e.start))
+        {
+            sb.Remove(start, length).Insert(start, replacement);
+        }
+
+        return (sb.ToString(), edits.Count);
+    }
+
+    // --------------------------------------------------------
+    // Core per-file processing logic
+    // --------------------------------------------------------
+    private static async Task<int> ProcessFileAsync(string path, bool backup, bool verbose, SemaphoreSlim sem)
+    {
+        await sem.WaitAsync();
+        try
+        {
+            var source = await File.ReadAllTextAsync(path);
+            var (result, count) = await FixSourceAsync(source, path, ResolveSymbol);
+            if (count == 0) return 0;
+
+            if (backup)
+                File.Copy(path, path + ".bak", overwrite: true);
+
+            await File.WriteAllTextAsync(path, result);
+            if (verbose)
+                Console.WriteLine($"[{Path.GetFileName(path)}] fixed {count} identifier(s).");
+
+            return count;
+        }
+        finally
+        {
+            sem.Release();
+        }
+    }
+
+    // --------------------------------------------------------
+    // OmniSharp helpers
+    // --------------------------------------------------------
+    private static async Task<(string? Name, bool IsParameterless)> GetSymbolInfoAsync(string filePath, SyntaxTree tree, SyntaxToken token)
+    {
+        var pos = tree.GetLineSpan(token.Span).StartLinePosition;
+        var req = new GotoReq(filePath, pos.Line + 1, pos.Character + 1);
+        try
+        {
+            var res = await Http.PostAsJsonAsync("/v2/gotoDefinition", req);
+            if (!res.IsSuccessStatusCode) return default;
+            var data = await res.Content.ReadFromJsonAsync<GotoResp>();
+            var def = data?.Definitions.FirstOrDefault();
+            if (def == null) return default;
+
+            var guess = Path.GetFileNameWithoutExtension(def.FileName);
+            string? canonical = null;
+            bool isMethod = false;
+            if (string.Equals(guess, token.ValueText, StringComparison.OrdinalIgnoreCase))
+                canonical = guess;
+
+            if (File.Exists(def.FileName))
+            {
+                var defLines = await File.ReadAllLinesAsync(def.FileName);
+                var line = defLines.ElementAtOrDefault(def.Range.Start.Line - 1);
+                if (line != null && def.Range.Start.Column - 1 < line.Length)
+                {
+                    var length = def.Range.End.Column - def.Range.Start.Column;
+                    canonical ??= line.Substring(def.Range.Start.Column - 1, length);
+                    var after = line.Substring(def.Range.Start.Column - 1 + length);
+                    if (System.Text.RegularExpressions.Regex.IsMatch(after, @"^\s*\(\s*\)"))
+                        isMethod = true;
+                }
+            }
+            return (canonical, isMethod);
+        }
+        catch
+        {
+            // network / JSON error – ignore, compiler will report later
+        }
+        return default;
+    }
+
+    // --------------------------------------------------------
+    // DTOs for OmniSharp JSON contract (only what we use)
+    // --------------------------------------------------------
+    private record GotoReq(string FileName, int Line, int Column);
+    private record GotoResp([property: JsonPropertyName("definitions")] Location[] Definitions);
+    private record Location(string FileName, TextRange Range);
+    private record TextRange(Position Start, Position End);
+    private record Position(int Line, int Column);
+}

--- a/CaseFixer.csproj
+++ b/CaseFixer.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="CaseFixer.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+  </ItemGroup>
+</Project>

--- a/Readme.md
+++ b/Readme.md
@@ -79,6 +79,37 @@ Add this snippet to your `.csproj` to regenerate C# before each build:
 Now `dotnet build` or Visual Studio’s **Build** button transparently converts
 and compiles everything.
 
+### Fixing identifier casing
+
+Oxygene source is case-insensitive but C# is not. After transpilation you can
+run the optional `CaseFixer` utility to update the casing of identifiers by
+querying an OmniSharp server. Build the tool with `dotnet build` and execute it
+on the root of your generated C# files:
+
+```bash
+dotnet run --project CaseFixer.csproj ./MyProject --backup --threads 4
+```
+
+The tool rewrites the files in place (optionally keeping `.bak` backups) so your
+C# code matches the canonical casing known to Roslyn.
+
+### Installing OmniSharp
+
+`CaseFixer` expects an OmniSharp HTTP server listening on port `2000`.
+Run the provided script to download and unpack a local copy:
+
+```bash
+./install_omnisharp.sh
+```
+
+Start the server from your solution root:
+
+```bash
+~/.omnisharp/OmniSharp -s .
+```
+
+Then execute `CaseFixer` on your generated files.
+
 ---
 
 ## 🏗️  Extending

--- a/install_omnisharp.sh
+++ b/install_omnisharp.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Fetch OmniSharp HTTP server (net6.0) and unpack into ~/.omnisharp
+set -e
+VERSION="${VERSION:-v1.39.13}"
+DEST="$HOME/.omnisharp"
+mkdir -p "$DEST"
+URL="https://github.com/OmniSharp/omnisharp-roslyn/releases/download/$VERSION/omnisharp.http-linux-x64-net6.0.tar.gz"
+
+curl -L "$URL" -o "$DEST/omnisharp.tar.gz"
+tar -xzf "$DEST/omnisharp.tar.gz" -C "$DEST"
+rm "$DEST/omnisharp.tar.gz"
+
+cat <<EOM
+OmniSharp installed to $DEST.
+Start the server with:
+  $DEST/OmniSharp -s <path>
+EOM


### PR DESCRIPTION
## Summary
- add xUnit-based tests for CaseFixer
- expose internals to the new test project
- remove old Python test
- add multi-file test for CaseFixer

## Testing
- `dotnet test CaseFixer.Tests/CaseFixer.Tests.csproj -c Release`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866b7bc66b08331b3f0c4e3c5e14b78