### PR TITLE
Add Docker container for full project conversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+# Convert Oxygene projects to C#
+# Usage:
+#   docker run --rm -v $(pwd):/workspace pas2cs-convert
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY CaseFixer.csproj CaseFixer.csproj
+COPY CaseFixer.cs CaseFixer.cs
+RUN dotnet publish CaseFixer.csproj -c Release -o /casefixer
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0
+WORKDIR /tool
+COPY . /tool
+COPY --from=build /casefixer /tool/casefixer
+RUN apt-get update \
+    && apt-get install -y python3 python3-pip \
+    && pip3 install lark-parser \
+    && chmod +x /tool/run_conversion.sh
+
+WORKDIR /workspace
+ENTRYPOINT ["/tool/run_conversion.sh"]

--- a/run_conversion.sh
+++ b/run_conversion.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+project_dir="${1:-/workspace}"
+
+# Collect .pas files recursively
+mapfile -d '' files < <(find "$project_dir" -type f -name '*.pas' -print0)
+if [ ${#files[@]} -eq 0 ]; then
+    echo "No Pascal files found." >&2
+    exit 0
+fi
+
+# Transpile each file to C# next to the original
+for file in "${files[@]}"; do
+    python3 /tool/pas2cs.py "$file"
+    rm "$file"
+    echo "Converted ${file}"
+done
+
+# Fix identifier casing using CaseFixer
+# OmniSharp server is expected to be running on port 2000
+if [ -d "$project_dir" ]; then
+    dotnet /tool/casefixer/CaseFixer.dll "$project_dir" --threads $(nproc)
+fi
+
+echo "Conversion completed."


### PR DESCRIPTION
## Summary
- add Dockerfile that builds CaseFixer and installs Python tooling
- include `run_conversion.sh` entrypoint script

## Testing
- `pytest -q`
- `dotnet test CaseFixer.Tests/CaseFixer.Tests.csproj -v m`


------
https://chatgpt.com/codex/tasks/task_e_6866d1af39048331a1a107f68e2cc8ea