### PR TITLE
Add verbose logs for CaseFixer

### DIFF
--- a/CaseFixer.Tests/CaseFixerTests.cs
+++ b/CaseFixer.Tests/CaseFixerTests.cs
@@ -223,6 +223,7 @@ class Demo {
             Assert.Contains("OmniSharp for foo", output);
             Assert.Contains("foo -> Foo", output);
             Assert.Contains("added parentheses", output);
+            Assert.Contains("CompilationUnit", output);
         }
         finally
         {

--- a/CaseFixer.Tests/CaseFixerTests.cs
+++ b/CaseFixer.Tests/CaseFixerTests.cs
@@ -220,6 +220,7 @@ class Demo {
             Assert.Equal(0, exitCode);
 
             string output = sw.ToString();
+            Assert.Contains("OmniSharp for foo", output);
             Assert.Contains("foo -> Foo", output);
             Assert.Contains("added parentheses", output);
         }

--- a/CaseFixer.cs
+++ b/CaseFixer.cs
@@ -144,8 +144,18 @@ internal static class Program
             var original = token.ValueText;
             if (string.IsNullOrWhiteSpace(original)) continue;
 
+            if (verbose)
+            {
+                var tp = tree.GetLineSpan(token.Span).StartLinePosition;
+                Console.WriteLine($"  token {original} at {tp.Line + 1}:{tp.Character + 1}");
+            }
+
             if (CanonicalCaseCache.TryGetValue(original, out var cached))
             {
+                if (verbose)
+                {
+                    Console.WriteLine($"  cache for {original} -> {cached.Name} (method={cached.IsMethod})");
+                }
                 if (!string.Equals(original, cached.Name, StringComparison.Ordinal))
                 {
                     edits.Add((token.SpanStart, token.Span.Length, cached.Name));
@@ -175,6 +185,10 @@ internal static class Program
             }
 
             var (symbolName, isMethod) = await resolver(filePath, tree, token);
+            if (verbose)
+            {
+                Console.WriteLine($"  OmniSharp for {original} -> {(symbolName ?? "null")} (paramless={isMethod})");
+            }
             if (symbolName is null && !isMethod) continue;
 
             if (symbolName is not null)

--- a/CaseFixer.cs
+++ b/CaseFixer.cs
@@ -232,7 +232,15 @@ internal static class Program
             sb.Remove(start, length).Insert(start, replacement);
         }
 
-        return (sb.ToString(), edits.Count);
+        var result = sb.ToString();
+        if (verbose)
+        {
+            Console.WriteLine("--- syntax tree ---");
+            var newRoot = CSharpSyntaxTree.ParseText(result).GetRoot();
+            DumpSyntaxTree(newRoot, "");
+        }
+
+        return (result, edits.Count);
     }
 
     // --------------------------------------------------------
@@ -362,4 +370,22 @@ internal static class Program
     private record Position(int Line, int Column);
     private record AutoCompleteReq(string FileName, int Line, int Column, string Buffer, string WordToComplete, bool WantMethodHeader, bool WantKind, bool WantSnippet);
     private record AutoCompleteResp(string CompletionText, string DisplayText, string Snippet, string Kind, string MethodHeader);
+
+    private static void DumpSyntaxTree(SyntaxNode node, string indent)
+    {
+        Console.WriteLine($"{indent}{node.Kind()}");
+        indent += "  ";
+        foreach (var child in node.ChildNodesAndTokens())
+        {
+            if (child.IsNode)
+            {
+                DumpSyntaxTree(child.AsNode()!, indent);
+            }
+            else
+            {
+                var tok = child.AsToken();
+                Console.WriteLine($"{indent}{tok.Kind()} {tok.ValueText}");
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- add verbose logging to `CaseFixer` to show each edit
- log file processing
- capture verbose output in new unit test

## Testing
- `pip install lark-parser`
- `dotnet test CaseFixer.Tests/CaseFixer.Tests.csproj --no-build` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68711ed5a7d483318f2ccb84c078249a