### PR TITLE
Add Roslyn fallback for CaseFixer

### DIFF
--- a/CaseFixer.Tests/CaseFixerTests.cs
+++ b/CaseFixer.Tests/CaseFixerTests.cs
@@ -25,8 +25,7 @@ public class CaseFixerTests
 }";
             File.WriteAllText(file, original);
 
-            using var resolver = new RoslynResolver(tempDir);
-            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1" });
+            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1", "--roslyn" });
             Assert.Equal(0, exitCode);
 
             string result = File.ReadAllText(file);
@@ -60,8 +59,7 @@ public class CaseFixerTests
     }
 }");
 
-            using var resolver = new RoslynResolver(tempDir);
-            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1" });
+            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1", "--roslyn" });
             Assert.Equal(0, exitCode);
 
             string result1 = File.ReadAllText(file1);
@@ -91,8 +89,7 @@ public class CaseFixerTests
     }
 }");
 
-            using var resolver = new RoslynResolver(tempDir);
-            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1" });
+            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1", "--roslyn" });
             Assert.Equal(0, exitCode);
 
             string result = File.ReadAllText(file);
@@ -120,8 +117,7 @@ class Demo {
         var str = s.tostring;
     }
 }");
-            using var resolver = new RoslynResolver(tempDir);
-            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1" });
+            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1", "--roslyn" });
             Assert.Equal(0, exitCode);
 
             string result = File.ReadAllText(file);
@@ -150,8 +146,7 @@ class Demo {
     }
 }";
             File.WriteAllText(file, original);
-            using var resolver = new RoslynResolver(tempDir);
-            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1", "--dry-run" });
+            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1", "--dry-run", "--roslyn" });
             Assert.Equal(0, exitCode);
             string result = File.ReadAllText(file);
             Assert.Equal(original.Replace("\r", ""), result.Replace("\r", ""));
@@ -178,8 +173,7 @@ class Demo {
     }
 }");
 
-            using var resolver = new RoslynResolver(tempDir);
-            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1" });
+            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1", "--roslyn" });
             Assert.Equal(0, exitCode);
 
             string result = File.ReadAllText(file).Replace("\r", "");
@@ -209,18 +203,17 @@ class Demo {
     }
 }");
 
-            using var resolver = new RoslynResolver(tempDir);
             var sw = new StringWriter();
             var originalOut = Console.Out;
             Console.SetOut(sw);
 
-            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1", "--verbose" });
+            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1", "--verbose", "--roslyn" });
 
             Console.SetOut(originalOut);
             Assert.Equal(0, exitCode);
 
             string output = sw.ToString();
-            Assert.Contains("OmniSharp for foo", output);
+            Assert.Contains("resolved for foo", output);
             Assert.Contains("foo -> Foo", output);
             Assert.Contains("added parentheses", output);
             Assert.Contains("CompilationUnit", output);

--- a/CaseFixer.Tests/CaseFixerTests.cs
+++ b/CaseFixer.Tests/CaseFixerTests.cs
@@ -131,6 +131,36 @@ class Demo {
     }
 
     [Fact]
+    public async Task FixesBuiltInMethodNamesOmniSharp()
+    {
+        var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(tempDir);
+        Program.ResetCache();
+        try
+        {
+            var file = Path.Combine(tempDir, "Demo.cs");
+            File.WriteAllText(file, @"using System.Collections.Generic;
+class Demo {
+    void Bar() {
+        var list = new List<int>();
+        var s = list.tolist();
+        var str = s.tostring;
+    }
+}");
+            int exitCode = await Program.Main(new[] { tempDir, "--threads", "1" });
+            Assert.Equal(0, exitCode);
+
+            string result = File.ReadAllText(file);
+            Assert.Contains("ToList()", result);
+            Assert.Contains("ToString()", result);
+        }
+        finally
+        {
+            Directory.Delete(tempDir, true);
+        }
+    }
+
+    [Fact]
     public async Task DryRunDoesNotModifyFiles()
     {
         var tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());

--- a/CaseFixer.csproj
+++ b/CaseFixer.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CaseFixer.cs" />
+    <Compile Include="RoslynResolver.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />

--- a/Readme.md
+++ b/Readme.md
@@ -83,7 +83,7 @@ and compiles everything.
 
 Oxygene source is case-insensitive but C# is not. After transpilation you can
 run the optional `CaseFixer` utility to update the casing of identifiers by
-querying an OmniSharp server. When using the Docker image the included
+querying an OmniSharp server or using a built-in Roslyn resolver. When using the Docker image the included
 `run_conversion.sh` script will launch OmniSharp automatically. Otherwise build
 the tool with `dotnet build` and execute it on the root of your generated C#
 files:
@@ -92,6 +92,8 @@ files:
 dotnet run --project CaseFixer.csproj ./MyProject --backup --threads 4
 # preview changes without modifying files
 dotnet run --project CaseFixer.csproj ./MyProject --dry-run
+# use Roslyn instead of OmniSharp
+dotnet run --project CaseFixer.csproj ./MyProject --roslyn
 ```
 
 The tool rewrites the files in place (optionally keeping `.bak` backups) so your
@@ -99,7 +101,7 @@ C# code matches the canonical casing known to Roslyn.
 
 ### Installing OmniSharp
 
-`CaseFixer` expects an OmniSharp HTTP server listening on port `2000`.
+`CaseFixer` expects an OmniSharp HTTP server listening on port `2000` unless `--roslyn` is used.
 When using the provided Docker image this server is started automatically.
 For a manual setup, run the script below to download and unpack OmniSharp:
 

--- a/Readme.md
+++ b/Readme.md
@@ -94,6 +94,7 @@ dotnet run --project CaseFixer.csproj ./MyProject --backup --threads 4
 dotnet run --project CaseFixer.csproj ./MyProject --dry-run
 # use Roslyn instead of OmniSharp
 dotnet run --project CaseFixer.csproj ./MyProject --roslyn
+# built-in APIs like ToString and ToList are fixed automatically
 ```
 
 The tool rewrites the files in place (optionally keeping `.bak` backups) so your

--- a/Readme.md
+++ b/Readme.md
@@ -94,7 +94,7 @@ dotnet run --project CaseFixer.csproj ./MyProject --backup --threads 4
 dotnet run --project CaseFixer.csproj ./MyProject --dry-run
 # use Roslyn instead of OmniSharp
 dotnet run --project CaseFixer.csproj ./MyProject --roslyn
-# built-in APIs like ToString and ToList are fixed automatically
+# built-in APIs like ToString and ToList are fixed automatically with either resolver
 ```
 
 The tool rewrites the files in place (optionally keeping `.bak` backups) so your

--- a/Readme.md
+++ b/Readme.md
@@ -100,6 +100,14 @@ dotnet run --project CaseFixer.csproj ./MyProject --roslyn
 The tool rewrites the files in place (optionally keeping `.bak` backups) so your
 C# code matches the canonical casing known to Roslyn.
 
+### Handling syntax errors
+
+In some cases the transpiler may leave stray characters when it encounters
+unsupported Pascal constructs. If the C# compiler reports simple errors like
+`CS1002` (`;` expected), inspect the generated file at the reported line and
+remove the offending token or add the missing semicolon. These issues are rare
+and usually stem from unusual Pascal syntax.
+
 ### Installing OmniSharp
 
 `CaseFixer` expects an OmniSharp HTTP server listening on port `2000` unless `--roslyn` is used.

--- a/RoslynResolver.cs
+++ b/RoslynResolver.cs
@@ -7,27 +7,33 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
-namespace CaseFixer.Tests;
+namespace CaseFixer;
 
-internal sealed class RoslynResolver : IDisposable
+internal sealed class RoslynResolver
 {
     private readonly string _root;
-    private readonly Program.SymbolResolver _previous;
     private CSharpCompilation? _comp;
+    private readonly object _lock = new();
 
     public RoslynResolver(string root)
     {
         _root = root;
-        _previous = Program.ResolveSymbol;
-        Program.ResolveSymbol = ResolveAsync;
     }
 
     public async Task<(string? Name, bool IsParameterless)> ResolveAsync(string filePath, SyntaxTree tree, SyntaxToken token)
     {
         if (_comp == null)
-            await BuildCompilationAsync(filePath, tree);
+        {
+            lock (_lock)
+            {
+                if (_comp == null)
+                {
+                    _comp = BuildCompilationAsync(filePath, tree).GetAwaiter().GetResult();
+                }
+            }
+        }
 
-        var treeInComp = _comp.SyntaxTrees.FirstOrDefault(t => t.FilePath == tree.FilePath) ?? tree;
+        var treeInComp = _comp.SyntaxTrees.FirstOrDefault(t => Path.GetFullPath(t.FilePath) == Path.GetFullPath(tree.FilePath)) ?? tree;
         var model = _comp.GetSemanticModel(treeInComp);
         var tokenInComp = treeInComp.GetRoot().FindToken(token.SpanStart);
         SyntaxNode node = tokenInComp.Parent!;
@@ -52,7 +58,7 @@ internal sealed class RoslynResolver : IDisposable
         return (symbol.Name, paramless);
     }
 
-    private async Task BuildCompilationAsync(string mainPath, SyntaxTree mainTree)
+    private async Task<CSharpCompilation> BuildCompilationAsync(string mainPath, SyntaxTree mainTree)
     {
         var trees = new List<SyntaxTree>();
         var files = Directory.GetFiles(_root, "*.cs");
@@ -69,12 +75,7 @@ internal sealed class RoslynResolver : IDisposable
             .Select(a => MetadataReference.CreateFromFile(a.Location))
             .ToList();
 
-        _comp = CSharpCompilation.Create("CaseFixerTests", trees, refs,
+        return CSharpCompilation.Create("CaseFixer", trees, refs,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
-    }
-
-    public void Dispose()
-    {
-        Program.ResolveSymbol = _previous;
     }
 }


### PR DESCRIPTION
## Summary
- add a Roslyn-based symbol resolver
- allow `CaseFixer` to use `--roslyn`
- update docs for the new option
- refactor tests to use the flag and drop the old resolver file

## Testing
- `pip install lark-parser`
- `pytest -q`
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68713f38de80833196c324cbd8f6531e